### PR TITLE
feat(csp): drop 'unsafe-inline' from style-src

### DIFF
--- a/customers/customers.php
+++ b/customers/customers.php
@@ -42,14 +42,14 @@ $all_customers = find_all('customers');
           <table class="table table-bordered table-striped">
           <thead>
                 <tr>
-                    <th class="text-center" style="width: 100px;">Customer</th>
-                    <th class="text-center" style="width: 100px;">City</th>
-                    <th class="text-center" style="width: 50px;">Region</th>
-                    <th class="text-center" style="width: 50px;">Code</th>
-                    <th class="text-center" style="width: 50px;">Telephone</th>
-                    <th class="text-center" style="width: 50px;">Email</th>
-                    <th class="text-center" style="width: 50px;">Pay Method</th>
-                    <th class="text-center" style="width: 50px;">Actions</th>
+                    <th class="text-center col-w-100">Customer</th>
+                    <th class="text-center col-w-100">City</th>
+                    <th class="text-center col-w-50">Region</th>
+                    <th class="text-center col-w-50">Code</th>
+                    <th class="text-center col-w-50">Telephone</th>
+                    <th class="text-center col-w-50">Email</th>
+                    <th class="text-center col-w-50">Pay Method</th>
+                    <th class="text-center col-w-50">Actions</th>
                 </tr>
             </thead>
             <tbody>

--- a/docs/gap-analysis.md
+++ b/docs/gap-analysis.md
@@ -2,7 +2,7 @@
 
 Snapshot of feature completeness, test coverage, and known issues for the Inventory Management System.
 
-**Last regenerated**: 2026-05-15 (third pass — migrations applied, upload.php prepared, CSP tightened, CI added)
+**Last regenerated**: 2026-05-15 (fourth pass — `style-src` tightened to `'self'` only)
 **Codebase commit**: post-install.sh-reinstall, post-PHP8-type-strictness fixes, post-hardening pass, post-CI
 
 ---
@@ -56,7 +56,7 @@ These were live bugs in `main` and have been patched:
 | `tests/CRUDTest.php` failed silently — wrong column name + missing NOT NULL fields + missing parent category | `tests/CRUDTest.php` | HIGH | Fixed column name, provisioned HARNESS category for FK, used `check()` helper instead of `assert()` |
 | `tests/bootstrap.php` did not buffer output, so `session_regenerate_id()` failed in the SessionTest after prior `echo`s | `tests/bootstrap.php` | MEDIUM | Added `ob_start()` at bootstrap entry |
 | `tests/*.php` used `assert()` — a no-op on default PHP 8 configurations | `tests/AuthTest.php`, `tests/CRUDTest.php` | MEDIUM | Added `check()` helper that throws on failure |
-| CSP / X-Frame-Options / Referrer-Policy / Permissions-Policy headers missing | `includes/load.php` | HIGH | Emit on every request (CSP allows `'self'` + `'unsafe-inline'` for bundled Bootstrap/jQuery) |
+| CSP / X-Frame-Options / Referrer-Policy / Permissions-Policy headers missing | `includes/load.php` | HIGH | Emit on every request (CSP is `'self'` only for `script-src` *and* `style-src` — no `'unsafe-inline'`) |
 | No login rate limiting — credential stuffing unmitigated | `users/auth.php`, `failed_logins` table | HIGH | Added migration 002, helpers in `sql.php`, check + record + clear in `auth.php` (5 attempts per 15 min per IP) |
 | No password complexity enforcement — single-char passwords accepted | `users/add_user.php`, `users/edit_user.php`, `users/change_password.php` | MEDIUM | Added `validate_password()` helper (min 8 chars, must contain letter + digit, denylist of common passwords) |
 | `quantity` columns were VARCHAR(50) | `schema.sql`, `migrations/001_quantity_int.up.sql`, `migrations/001_quantity_int.down.sql` | HIGH | Migration 001 created; `schema.sql` updated for fresh installs (INT NOT NULL DEFAULT 0) |
@@ -80,8 +80,6 @@ These were live bugs in `main` and have been patched:
 
 **No browser-level UI/integration tests** — `tests/SecurityHeadersTest.php` exercises HTTP responses but there's no Playwright/Selenium coverage of actual page interactions.
 
-**CSP keeps `'unsafe-inline'` for `style-src`** — Bootstrap's JS sets inline style attributes (dropdowns, popovers, tooltips) at runtime; removing this would break common UI controls. `script-src` is now `'self'` only after moving inline handlers to `libs/js/functions.js`.
-
 **`orders.customer` is a varchar (denormalized)** — should be FK to `customers.id` for referential integrity. Pre-existing schema decision; preserved to avoid breaking changes.
 
 ---
@@ -100,7 +98,7 @@ Cross-reference of `docs/*.md` claims against actual code:
 | "CI pipeline" | `gap-analysis.md` prior pass | ✅ ADDED 2026-05-15 — `.github/workflows/ci.yml` runs `php -l` + full test suite on push/PR |
 | "Security headers test" | `gap-analysis.md` prior pass | ✅ ADDED 2026-05-15 — `tests/SecurityHeadersTest.php` (7 tests) |
 | "failed_logins housekeeping" | `gap-analysis.md` prior pass | ✅ ADDED 2026-05-15 — probabilistic prune (~1% of page loads) via `prune_failed_logins()` |
-| "Inline JS / CSP tightening" | `gap-analysis.md` prior pass | ✅ MOSTLY DONE 2026-05-15 — moved `closePanel()` to `libs/js/functions.js`, replaced 4 redirect stubs with server-side redirects, CSP `script-src` is now `'self'` only |
+| "Inline JS / CSP tightening" | `gap-analysis.md` prior pass | ✅ DONE 2026-05-15 — `script-src 'self'` after moving `closePanel()` to `libs/js/functions.js`; `style-src 'self'` after replacing 117 `style="width:X"` attrs with `col-w-*` utility classes (`libs/css/main.css`) and extracting 4 print blocks into `libs/css/print.css` |
 | "log.user_id FK for audit-trail preservation" | `gap-analysis.md` prior pass | ✅ DESIGNED 2026-05-15 — migration 003 ready; schema.sql updated for fresh installs |
 | "Soft delete with restore" | none — but typical for audit-heavy apps | NOT IMPLEMENTED — `delete_by_id()` is hard delete. Scoped + deferred (see section 3) |
 
@@ -121,9 +119,7 @@ Cross-reference of `docs/*.md` claims against actual code:
 
 Most prior-pass items now resolved (see section 4 below). Remaining work:
 
-1. **Apply migration 003 to running deployments** — backup, then `sudo mysql inventory < migrations/003_log_user_fk.up.sql`.
-2. **Soft-delete refactor** (its own PR) — `deleted_at` columns + `soft_delete_by_id()` + `restore_by_id()` + filter every SELECT. See section 3 above for scope.
-3. **Tighten `style-src`** — extract Bootstrap inline-style usages (animations, popovers) to either CSS classes or nonce-permitted blocks.
-4. **Per-tenant currency** — make `$CURRENCY_CODE` a column in a settings table or `.env` value.
-5. **Browser-level UI tests** — Playwright covering the login → add-product → add-sale → invoice happy path.
-6. **Pre-commit hook** for `php -l` on staged files (the CI catches this on push but pre-commit prevents bad commits).
+1. **Soft-delete refactor** (its own PR) — `deleted_at` columns + `soft_delete_by_id()` + `restore_by_id()` + filter every SELECT. See section 3 above for scope.
+2. **Per-tenant currency** — make `$CURRENCY_CODE` a column in a settings table or `.env` value.
+3. **Browser-level UI tests** — Playwright covering the login → add-product → add-sale → invoice happy path.
+4. **Pre-commit hook** for `php -l` on staged files (the CI catches this on push but pre-commit prevents bad commits).

--- a/includes/load.php
+++ b/includes/load.php
@@ -32,23 +32,22 @@ if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') {
 // -----------------------------------------------------------------------
 // Security response headers — emitted on every request.
 //
-// CSP is intentionally permissive ('self' + inline styles/scripts) because
-// the project bundles Bootstrap 5 and jQuery with inline onclick handlers.
-// Tightening this requires refactoring inline JS out of the templates;
-// tracked in docs/gap-analysis.md.
+// CSP is tight: 'self' only for scripts and styles, no 'unsafe-inline' or
+// 'unsafe-eval'. Inline JS lives in libs/js/functions.js; column-width
+// utility classes (libs/css/main.css) replaced inline style="" attributes;
+// print/report pages link libs/css/print.css.
 // -----------------------------------------------------------------------
 if (PHP_SAPI !== 'cli' && !headers_sent()) {
-    // script-src: 'self' only — no 'unsafe-inline'. All inline JS has been
-    //   moved to libs/js/functions.js. New inline scripts must use a nonce
-    //   or be moved to an external file.
-    // style-src: keeps 'unsafe-inline' because Bootstrap and jQuery
-    //   plugins (dropdowns, tooltips, popovers) set inline style attributes
-    //   at runtime. Removing it would break common UI controls. Tracked in
-    //   docs/gap-analysis.md as an accepted constraint.
+    // script-src: 'self' only — no 'unsafe-inline'. New inline scripts must
+    //   use a nonce or be moved to an external file.
+    // style-src: 'self' only — no 'unsafe-inline'. CSP style-src governs
+    //   <style> blocks and HTML-parsed style="" attributes, not runtime
+    //   element.style.X or jQuery .css() (those are script-side), so the
+    //   bundled Bootstrap/jQuery plugins continue to work.
     header("Content-Security-Policy: "
         . "default-src 'self'; "
         . "script-src 'self'; "
-        . "style-src 'self' 'unsafe-inline'; "
+        . "style-src 'self'; "
         . "img-src 'self' data:; "
         . "font-src 'self'; "
         . "object-src 'none'; "

--- a/libs/css/main.css
+++ b/libs/css/main.css
@@ -309,3 +309,11 @@ input[type=file]{
   width: 125px;
   height: 125px;
 }
+/* Column-width utilities — replace inline style="width:X" so style-src can drop 'unsafe-inline'. */
+.col-w-15{ width: 15px; }
+.col-w-50{ width: 50px; }
+.col-w-100{ width: 100px; }
+.col-w-10p{ width: 10%; }
+.col-w-15p{ width: 15%; }
+.col-w-20p{ width: 20%; }
+

--- a/libs/css/print.css
+++ b/libs/css/print.css
@@ -1,0 +1,57 @@
+/* Shared print/invoice styles for sales_invoice, order_picklist, sale_report_process, stock_report_process. */
+@media print {
+  html, body {
+    font-size: 9.5pt;
+    margin: 0;
+    padding: 0;
+  }
+  .page-break {
+    page-break-before: always;
+    width: auto;
+    margin: auto;
+  }
+}
+.page-break {
+  width: 980px;
+  margin: 0 auto;
+}
+.sale-head {
+  margin: 40px 0;
+  text-align: center;
+}
+.sale-head h1,
+.sale-head strong {
+  padding: 10px 20px;
+  display: block;
+}
+.sale-head h1 {
+  margin: 0;
+  border-bottom: 1px solid #212121;
+}
+.table > thead:first-child > tr:first-child > th {
+  border-top: 1px solid #000;
+}
+table thead tr th {
+  text-align: center;
+  border: 1px solid #ededed;
+}
+table tbody tr td {
+  vertical-align: middle;
+}
+.sale-head,
+table.table thead tr th,
+table tbody tr td,
+table tfoot tr td {
+  border: 1px solid #212121;
+  white-space: nowrap;
+}
+.sale-head h1,
+table thead tr th,
+table tfoot tr td {
+  background-color: #f8f8f8;
+}
+tfoot {
+  color: #000;
+  text-transform: uppercase;
+  font-weight: 500;
+}

--- a/products/categories.php
+++ b/products/categories.php
@@ -90,11 +90,11 @@ $req_field = array('category-name');
           <table class="table table-bordered table-striped table-hover">
             <thead>
                 <tr>
-                    <th class="text-center" style="width: 50px;">#</th>
+                    <th class="text-center col-w-50">#</th>
 <!--     *************************     -->
                     <th>Categories</th>
 <!--     *************************     -->
-                    <th class="text-center" style="width: 100px;">Actions</th>
+                    <th class="text-center col-w-100">Actions</th>
                 </tr>
             </thead>
             <tbody>

--- a/products/media.php
+++ b/products/media.php
@@ -56,11 +56,11 @@ if (isset($_POST['submit'])) {
             <table class="table">
               <thead>
                 <tr>
-                  <th class="text-center" style="width: 50px;">#</th>
+                  <th class="text-center col-w-50">#</th>
                   <th class="text-center">Photo</th>
                   <th class="text-center">Photo Name</th>
-                  <th class="text-center" style="width: 20%;">Photo Type</th>
-                  <th class="text-center" style="width: 50px;">Actions</th>
+                  <th class="text-center col-w-20p">Photo Type</th>
+                  <th class="text-center col-w-50">Actions</th>
                 </tr>
               </thead>
                 <tbody>

--- a/products/product_search.php
+++ b/products/product_search.php
@@ -47,12 +47,12 @@ page_require_level(3);
            <thead>
                 <th> Product Name </th>
                 <th> Photo</th>
-                <th class="text-center" style="width: 10%;"> SKU </th>
-                <th class="text-center" style="width: 10%;"> Location </th>
-                <th class="text-center" style="width: 10%;"> Stock </th>
-                <th class="text-center" style="width: 10%;"> Cost Price </th>
-                <th class="text-center" style="width: 10%;"> Sale Price </th>
-                <th class="text-center" style="width: 100px;"> Actions </th>
+                <th class="text-center col-w-10p"> SKU </th>
+                <th class="text-center col-w-10p"> Location </th>
+                <th class="text-center col-w-10p"> Stock </th>
+                <th class="text-center col-w-10p"> Cost Price </th>
+                <th class="text-center col-w-10p"> Sale Price </th>
+                <th class="text-center col-w-100"> Actions </th>
            </thead>
              <tbody  id="product_info"> </tbody>
          </table>

--- a/products/products.php
+++ b/products/products.php
@@ -85,14 +85,14 @@ if ( ( isset($_POST['update_category'] ) ) && ( $selected_category > 0 ) ) {
 <!--     *************************     -->
                 <th> Product </th>
                 <th> Photo</th>
-                <th class="text-center" style="width: 10%;"> SKU</th>
-                <th class="text-center" style="width: 10%;"> Category </th>
-                <th class="text-center" style="width: 10%;"> Location </th>
-                <th class="text-center" style="width: 10%;"> Stock </th>
-                <th class="text-center" style="width: 10%;"> Cost Price </th>
-                <th class="text-center" style="width: 10%;"> Sale Price </th>
-                <th class="text-center" style="width: 10%;"> Product Added </th>
-                <th class="text-center" style="width: 100px;"> Actions </th>
+                <th class="text-center col-w-10p"> SKU</th>
+                <th class="text-center col-w-10p"> Category </th>
+                <th class="text-center col-w-10p"> Location </th>
+                <th class="text-center col-w-10p"> Stock </th>
+                <th class="text-center col-w-10p"> Cost Price </th>
+                <th class="text-center col-w-10p"> Sale Price </th>
+                <th class="text-center col-w-10p"> Product Added </th>
+                <th class="text-center col-w-100"> Actions </th>
               </tr>
 <!--     *************************     -->
             </thead>

--- a/products/stock.php
+++ b/products/stock.php
@@ -39,11 +39,11 @@ $all_products = find_all('products');
           <table class="table table-bordered table-striped">
             <thead>
                 <tr>
-                    <th class="text-center" style="width: 50px;">Product</th>
-                    <th class="text-center" style="width: 50px;">Quantity</th>
-                    <th class="text-center" style="width: 50px;">Comments</th>
-                    <th class="text-center" style="width: 50px;">Date</th>
-                    <th class="text-center" style="width: 100px;">Actions</th>
+                    <th class="text-center col-w-50">Product</th>
+                    <th class="text-center col-w-50">Quantity</th>
+                    <th class="text-center col-w-50">Comments</th>
+                    <th class="text-center col-w-50">Date</th>
+                    <th class="text-center col-w-100">Actions</th>
                 </tr>
             </thead>
             <tbody>

--- a/products/view_product.php
+++ b/products/view_product.php
@@ -97,14 +97,14 @@ foreach ($all_photo as $photo) {
             <thead>
               <tr>
 <!--     *************************     -->
-                <th class="text-center" style="width: 10%;"> Category </th>
-                <th class="text-center" style="width: 10%;"> Location </th>
-                <th class="text-center" style="width: 10%;"> SKU </th>
-                <th class="text-center" style="width: 10%;"> Stock </th>
-                <th class="text-center" style="width: 15%;"> Cost Price </th>
-                <th class="text-center" style="width: 15%;"> Sale Price </th>
-                <th class="text-center" style="width: 15%;"> Product Added </th>
-                <th class="text-center" style="width: 50px;"> Actions </th>
+                <th class="text-center col-w-10p"> Category </th>
+                <th class="text-center col-w-10p"> Location </th>
+                <th class="text-center col-w-10p"> SKU </th>
+                <th class="text-center col-w-10p"> Stock </th>
+                <th class="text-center col-w-15p"> Cost Price </th>
+                <th class="text-center col-w-15p"> Sale Price </th>
+                <th class="text-center col-w-15p"> Product Added </th>
+                <th class="text-center col-w-50"> Actions </th>
               </tr>
 <!--     *************************     -->
             </thead>

--- a/reports/daily_sales.php
+++ b/reports/daily_sales.php
@@ -36,11 +36,11 @@ $sales = dailySales($year, $month);
           <table class="table table-bordered table-striped">
             <thead>
               <tr>
-                <th class="text-center" style="width: 50px;">#</th>
+                <th class="text-center col-w-50">#</th>
                 <th> Product </th>
-                <th class="text-center" style="width: 15%;"> Quantity sold</th>
-                <th class="text-center" style="width: 15%;"> Total </th>
-                <th class="text-center" style="width: 15%;"> Date </th>
+                <th class="text-center col-w-15p"> Quantity sold</th>
+                <th class="text-center col-w-15p"> Total </th>
+                <th class="text-center col-w-15p"> Date </th>
              </tr>
             </thead>
            <tbody>

--- a/reports/monthly_sales.php
+++ b/reports/monthly_sales.php
@@ -34,11 +34,11 @@ $sales = monthlySales($year);
           <table class="table table-bordered table-striped">
             <thead>
               <tr>
-                <th class="text-center" style="width: 50px;">#</th>
+                <th class="text-center col-w-50">#</th>
                 <th> Product </th>
-                <th class="text-center" style="width: 15%;"> Quantity Sold</th>
-                <th class="text-center" style="width: 15%;"> Total </th>
-                <th class="text-center" style="width: 15%;"> Date </th>
+                <th class="text-center col-w-15p"> Quantity Sold</th>
+                <th class="text-center col-w-15p"> Total </th>
+                <th class="text-center col-w-15p"> Date </th>
              </tr>
             </thead>
            <tbody>

--- a/reports/sale_report_process.php
+++ b/reports/sale_report_process.php
@@ -38,50 +38,7 @@ if (isset($_POST['submit'])) {
    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
    <title>Sales Report</title>
      <link rel="stylesheet" href="../libs/bootstrap/css/bootstrap.min.css"/>
-   <style>
-   @media print {
-     html,body{
-        font-size: 9.5pt;
-        margin: 0;
-        padding: 0;
-     }.page-break {
-       page-break-before:always;
-       width: auto;
-       margin: auto;
-      }
-    }
-    .page-break{
-      width: 980px;
-      margin: 0 auto;
-    }
-     .sale-head{
-       margin: 40px 0;
-       text-align: center;
-     }.sale-head h1,.sale-head strong{
-       padding: 10px 20px;
-       display: block;
-     }.sale-head h1{
-       margin: 0;
-       border-bottom: 1px solid #212121;
-     }.table>thead:first-child>tr:first-child>th{
-       border-top: 1px solid #000;
-      }
-      table thead tr th {
-       text-align: center;
-       border: 1px solid #ededed;
-     }table tbody tr td{
-       vertical-align: middle;
-     }.sale-head,table.table thead tr th,table tbody tr td,table tfoot tr td{
-       border: 1px solid #212121;
-       white-space: nowrap;
-     }.sale-head h1,table thead tr th,table tfoot tr td{
-       background-color: #f8f8f8;
-     }tfoot{
-       color:#000;
-       text-transform: uppercase;
-       font-weight: 500;
-     }
-   </style>
+   <link rel="stylesheet" href="../libs/css/print.css"/>
 </head>
 <body>
   <?php if ($results): ?>

--- a/reports/stock_report_process.php
+++ b/reports/stock_report_process.php
@@ -33,50 +33,7 @@ if (isset($_POST['submit'])) {
    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
    <title>Stock Report</title>
      <link rel="stylesheet" href="../libs/bootstrap/css/bootstrap.min.css"/>
-   <style>
-   @media print {
-     html,body{
-        font-size: 9.5pt;
-        margin: 0;
-        padding: 0;
-     }.page-break {
-       page-break-before:always;
-       width: auto;
-       margin: auto;
-      }
-    }
-    .page-break{
-      width: 980px;
-      margin: 0 auto;
-    }
-     .sale-head{
-       margin: 40px 0;
-       text-align: center;
-     }.sale-head h1,.sale-head strong{
-       padding: 10px 20px;
-       display: block;
-     }.sale-head h1{
-       margin: 0;
-       border-bottom: 1px solid #212121;
-     }.table>thead:first-child>tr:first-child>th{
-       border-top: 1px solid #000;
-      }
-      table thead tr th {
-       text-align: center;
-       border: 1px solid #ededed;
-     }table tbody tr td{
-       vertical-align: middle;
-     }.sale-head,table.table thead tr th,table tbody tr td,table tfoot tr td{
-       border: 1px solid #212121;
-       white-space: nowrap;
-     }.sale-head h1,table thead tr th,table tfoot tr td{
-       background-color: #f8f8f8;
-     }tfoot{
-       color:#000;
-       text-transform: uppercase;
-       font-weight: 500;
-     }
-   </style>
+   <link rel="stylesheet" href="../libs/css/print.css"/>
 </head>
 <body>
   <?php if ($products): ?>

--- a/sales/add_order_by_customer.php
+++ b/sales/add_order_by_customer.php
@@ -104,11 +104,11 @@ $req_fields = array('customer-name', 'paymethod' );
          <table class="table table-bordered">
            <thead>
                 <tr>
-                    <th class="text-center" style="width: 100px;">Customer</th>
-                    <th class="text-center" style="width: 100px;">Address</th>
-                    <th class="text-center" style="width: 50px;">Postal Code</th>
-                    <th class="text-center" style="width: 50px;">Pay Method</th>
-                    <th class="text-center" style="width: 50px;">Actions</th>
+                    <th class="text-center col-w-100">Customer</th>
+                    <th class="text-center col-w-100">Address</th>
+                    <th class="text-center col-w-50">Postal Code</th>
+                    <th class="text-center col-w-50">Pay Method</th>
+                    <th class="text-center col-w-50">Actions</th>
                 </tr>
            </thead>
            <tbody  id="customer_info"> </tbody>

--- a/sales/add_sale_by_search.php
+++ b/sales/add_sale_by_search.php
@@ -109,14 +109,14 @@ $all_categories = find_all('categories');
       <div class="panel-body">
          <table class="table table-bordered">
            <thead>
-            <th class="text-center" style="width: 15px;"> Product </th>
-            <th class="text-center" style="width: 50px;"> Photo </th>
-            <th class="text-center" style="width: 15px;"> SKU </th>
-            <th class="text-center" style="width: 50px;"> Location </th>
-            <th class="text-center" style="width: 15px;"> Available </th>
-            <th class="text-center" style="width: 15px;"> Quantity </th>
-            <th class="text-center" style="width: 50px;"> Price </th>
-            <th class="text-center" style="width: 50px;"> Action</th>
+            <th class="text-center col-w-15"> Product </th>
+            <th class="text-center col-w-50"> Photo </th>
+            <th class="text-center col-w-15"> SKU </th>
+            <th class="text-center col-w-50"> Location </th>
+            <th class="text-center col-w-15"> Available </th>
+            <th class="text-center col-w-15"> Quantity </th>
+            <th class="text-center col-w-50"> Price </th>
+            <th class="text-center col-w-50"> Action</th>
            </thead>
 
 <?php

--- a/sales/add_sale_by_sku.php
+++ b/sales/add_sale_by_sku.php
@@ -96,14 +96,14 @@ $req_fields = array('s_id', 'quantity', 'price', 'total' );
               <?php echo csrf_field(); ?>
          <table class="table table-bordered">
            <thead>
-            <th class="text-center" style="width: 100px;">Product </th>
-            <th class="text-center" style="width: 50px;"> SKU </th>
-            <th class="text-center" style="width: 50px;"> Location </th>
-            <th class="text-center" style="width: 15px;"> Available </th>
-            <th class="text-center" style="width: 15px;"> Quantity </th>
-            <th class="text-center" style="width: 50px;"> Price </th>
-            <th class="text-center" style="width: 50px;"> Total </th>
-            <th class="text-center" style="width: 50px;"> Action</th>
+            <th class="text-center col-w-100">Product </th>
+            <th class="text-center col-w-50"> SKU </th>
+            <th class="text-center col-w-50"> Location </th>
+            <th class="text-center col-w-15"> Available </th>
+            <th class="text-center col-w-15"> Quantity </th>
+            <th class="text-center col-w-50"> Price </th>
+            <th class="text-center col-w-50"> Total </th>
+            <th class="text-center col-w-50"> Action</th>
            </thead>
              <tbody  id="product_info"> </tbody>
          </table>

--- a/sales/add_sale_to_order.php
+++ b/sales/add_sale_to_order.php
@@ -131,14 +131,14 @@ foreach ($all_categories as $cat) {
       <div class="panel-body">
          <table class="table table-bordered">
            <thead>
-            <th class="text-center" style="width: 15px;"> Product </th>
-            <th class="text-center" style="width: 50px;"> Photo </th>
-            <th class="text-center" style="width: 15px;"> SKU </th>
-            <th class="text-center" style="width: 50px;"> Location </th>
-            <th class="text-center" style="width: 15px;"> Available </th>
-            <th class="text-center" style="width: 15px;"> Quantity </th>
-            <th class="text-center" style="width: 50px;"> Price </th>
-            <th class="text-center" style="width: 50px;"> Action</th>
+            <th class="text-center col-w-15"> Product </th>
+            <th class="text-center col-w-50"> Photo </th>
+            <th class="text-center col-w-15"> SKU </th>
+            <th class="text-center col-w-50"> Location </th>
+            <th class="text-center col-w-15"> Available </th>
+            <th class="text-center col-w-15"> Quantity </th>
+            <th class="text-center col-w-50"> Price </th>
+            <th class="text-center col-w-50"> Action</th>
            </thead>
              <tbody  id="product_info">
 <?php

--- a/sales/order_picklist.php
+++ b/sales/order_picklist.php
@@ -31,50 +31,7 @@ $products_available = join_product_table();
    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
    <title>Order Picklist</title>
      <link rel="stylesheet" href="../libs/bootstrap/css/bootstrap.min.css"/>
-   <style>
-   @media print {
-     html,body{
-        font-size: 9.5pt;
-        margin: 0;
-        padding: 0;
-     }.page-break {
-       page-break-before:always;
-       width: auto;
-       margin: auto;
-      }
-    }
-    .page-break{
-      width: 980px;
-      margin: 0 auto;
-    }
-     .sale-head{
-       margin: 40px 0;
-       text-align: center;
-     }.sale-head h1,.sale-head strong{
-       padding: 10px 20px;
-       display: block;
-     }.sale-head h1{
-       margin: 0;
-       border-bottom: 1px solid #212121;
-     }.table>thead:first-child>tr:first-child>th{
-       border-top: 1px solid #000;
-      }
-      table thead tr th {
-       text-align: center;
-       border: 1px solid #ededed;
-     }table tbody tr td{
-       vertical-align: middle;
-     }.sale-head,table.table thead tr th,table tbody tr td,table tfoot tr td{
-       border: 1px solid #212121;
-       white-space: nowrap;
-     }.sale-head h1,table thead tr th,table tfoot tr td{
-       background-color: #f8f8f8;
-     }tfoot{
-       color:#000;
-       text-transform: uppercase;
-       font-weight: 500;
-     }
-   </style>
+   <link rel="stylesheet" href="../libs/css/print.css"/>
 </head>
 <body>
   <?php if ($sales): ?>

--- a/sales/orders.php
+++ b/sales/orders.php
@@ -38,12 +38,12 @@ $orders = array_reverse($all_orders);
           <table class="table table-bordered table-striped">
             <thead>
                 <tr>
-                    <th class="text-center" style="width: 50px;">#</th>
-                    <th class="text-center" style="width: 50px;">Customer</th>
-                    <th class="text-center" style="width: 50px;">Pay Method</th>
-                    <th class="text-center" style="width: 50px;">Notes</th>
-                    <th class="text-center" style="width: 50px;">Date</th>
-                    <th class="text-center" style="width: 100px;">Actions</th>
+                    <th class="text-center col-w-50">#</th>
+                    <th class="text-center col-w-50">Customer</th>
+                    <th class="text-center col-w-50">Pay Method</th>
+                    <th class="text-center col-w-50">Notes</th>
+                    <th class="text-center col-w-50">Date</th>
+                    <th class="text-center col-w-100">Actions</th>
                 </tr>
             </thead>
             <tbody>

--- a/sales/sales.php
+++ b/sales/sales.php
@@ -36,12 +36,12 @@ page_require_level(3);
           <table class="table table-bordered table-striped">
             <thead>
               <tr>
-                <th class="text-center" style="width: 15%;">Order</th>
+                <th class="text-center col-w-15p">Order</th>
                 <th> Product </th>
-                <th class="text-center" style="width: 15%;"> Quantity</th>
-                <th class="text-center" style="width: 15%;"> Total </th>
-                <th class="text-center" style="width: 15%;"> Date </th>
-                <th class="text-center" style="width: 100px;"> Actions </th>
+                <th class="text-center col-w-15p"> Quantity</th>
+                <th class="text-center col-w-15p"> Total </th>
+                <th class="text-center col-w-15p"> Date </th>
+                <th class="text-center col-w-100"> Actions </th>
              </tr>
             </thead>
 

--- a/sales/sales_by_order.php
+++ b/sales/sales_by_order.php
@@ -46,12 +46,12 @@ $order = find_by_id("orders", $order_id);
           <table class="table table-bordered table-striped table-hover">
             <thead>
                 <tr>
-                    <th class="text-center" style="width: 50px;">#</th>
-                    <th class="text-center" style="width: 50px;">Customer</th>
-                    <th class="text-center" style="width: 50px;">Pay Method</th>
-                    <th class="text-center" style="width: 50px;">Notes</th>
-                    <th class="text-center" style="width: 50px;">Date</th>
-                    <th class="text-center" style="width: 100px;">Actions</th>
+                    <th class="text-center col-w-50">#</th>
+                    <th class="text-center col-w-50">Customer</th>
+                    <th class="text-center col-w-50">Pay Method</th>
+                    <th class="text-center col-w-50">Notes</th>
+                    <th class="text-center col-w-50">Date</th>
+                    <th class="text-center col-w-100">Actions</th>
                 </tr>
             </thead>
             <tbody>
@@ -115,13 +115,13 @@ $order = find_by_id("orders", $order_id);
           <table class="table table-bordered table-striped">
             <thead>
               <tr>
-                <th class="text-center" style="width: 50px;">#</th>
+                <th class="text-center col-w-50">#</th>
                 <th> Product </th>
-                <th class="text-center" style="width: 15%;"> SKU </th>
-                <th class="text-center" style="width: 15%;"> Location </th>
-                <th class="text-center" style="width: 15%;"> Quantity </th>
-                <th class="text-center" style="width: 15%;"> Total </th>
-                <th class="text-center" style="width: 100px;"> Actions </th>
+                <th class="text-center col-w-15p"> SKU </th>
+                <th class="text-center col-w-15p"> Location </th>
+                <th class="text-center col-w-15p"> Quantity </th>
+                <th class="text-center col-w-15p"> Total </th>
+                <th class="text-center col-w-100"> Actions </th>
              </tr>
             </thead>
 

--- a/sales/sales_invoice.php
+++ b/sales/sales_invoice.php
@@ -31,50 +31,7 @@ $products_available = join_product_table();
    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
    <title>Sales Invoice</title>
      <link rel="stylesheet" href="../libs/bootstrap/css/bootstrap.min.css"/>
-   <style>
-   @media print {
-     html,body{
-        font-size: 9.5pt;
-        margin: 0;
-        padding: 0;
-     }.page-break {
-       page-break-before:always;
-       width: auto;
-       margin: auto;
-      }
-    }
-    .page-break{
-      width: 980px;
-      margin: 0 auto;
-    }
-     .sale-head{
-       margin: 40px 0;
-       text-align: center;
-     }.sale-head h1,.sale-head strong{
-       padding: 10px 20px;
-       display: block;
-     }.sale-head h1{
-       margin: 0;
-       border-bottom: 1px solid #212121;
-     }.table>thead:first-child>tr:first-child>th{
-       border-top: 1px solid #000;
-      }
-      table thead tr th {
-       text-align: center;
-       border: 1px solid #ededed;
-     }table tbody tr td{
-       vertical-align: middle;
-     }.sale-head,table.table thead tr th,table tbody tr td,table tfoot tr td{
-       border: 1px solid #212121;
-       white-space: nowrap;
-     }.sale-head h1,table thead tr th,table tfoot tr td{
-       background-color: #f8f8f8;
-     }tfoot{
-       color:#000;
-       text-transform: uppercase;
-       font-weight: 500;
-     }
-   </style>
+   <link rel="stylesheet" href="../libs/css/print.css"/>
 </head>
 <body>
   <?php if ($sales): ?>

--- a/tests/SecurityHeadersTest.php
+++ b/tests/SecurityHeadersTest.php
@@ -114,11 +114,16 @@ test('CSP also emitted on protected path (302 to login)', function () use ($base
     check(isset($h['content-security-policy']), 'CSP missing on home.php');
 });
 
-// 7. CSP must NOT include 'unsafe-eval' (script-src tightening guard).
-//    'unsafe-inline' is accepted today because of bundled Bootstrap/jQuery.
-test('CSP does not allow unsafe-eval', function () use ($probe) {
+// 7. CSP must NOT include 'unsafe-eval' or 'unsafe-inline' in script-src/style-src.
+//    Inline scripts moved to libs/js/functions.js; inline width styles moved
+//    to col-w-* utility classes in libs/css/main.css; print/report pages link
+//    libs/css/print.css.
+test('CSP does not allow unsafe-eval or unsafe-inline', function () use ($probe) {
     $csp = $probe['content-security-policy'] ?? '';
     check(strpos($csp, "'unsafe-eval'") === false, "CSP must not include 'unsafe-eval'");
+    check(strpos($csp, "'unsafe-inline'") === false, "CSP must not include 'unsafe-inline'");
+    check(strpos($csp, "style-src 'self';") !== false, "style-src should be 'self' only");
+    check(strpos($csp, "script-src 'self';") !== false, "script-src should be 'self' only");
 });
 
 echo "\n---\nResults: $pass passed, $fail failed\n";

--- a/users/admin.php
+++ b/users/admin.php
@@ -153,7 +153,7 @@ $recent_sales    = find_recent_sale_added('5')
           <table class="table table-striped table-bordered table-condensed">
        <thead>
          <tr>
-           <th class="text-center" style="width: 50px;">#</th>
+           <th class="text-center col-w-50">#</th>
            <th>Product</th>
            <th>Date</th>
            <th>Total Sale</th>

--- a/users/group.php
+++ b/users/group.php
@@ -40,13 +40,13 @@ $all_groups = find_all('user_groups');
       <table class="table table-bordered">
         <thead>
           <tr>
-            <th class="text-center" style="width: 50px;">#</th>
+            <th class="text-center col-w-50">#</th>
 <!--     *************************     -->
             <th>Group Name</th>
 <!--     *************************     -->
-            <th class="text-center" style="width: 20%;">Group Level</th>
-            <th class="text-center" style="width: 15%;">Status</th>
-            <th class="text-center" style="width: 100px;">Actions</th>
+            <th class="text-center col-w-20p">Group Level</th>
+            <th class="text-center col-w-15p">Status</th>
+            <th class="text-center col-w-100">Actions</th>
           </tr>
         </thead>
         <tbody>

--- a/users/home.php
+++ b/users/home.php
@@ -92,7 +92,7 @@ $recent_sales    = find_recent_sale_added('5')
           <table class="table table-striped table-bordered table-condensed">
        <thead>
          <tr>
-           <th class="text-center" style="width: 50px;">#</th>
+           <th class="text-center col-w-50">#</th>
            <th>Product</th>
            <th>Date</th>
            <th>Total Sale</th>

--- a/users/log.php
+++ b/users/log.php
@@ -66,12 +66,12 @@ $logs = find_all('log');
           <table class="table table-bordered table-striped">
             <thead>
               <tr>
-	<th class="text-center" style="width: 15%;"> id  </th>
-	<th class="text-center" style="width: 15%;"> user_id  </th>
-	<th class="text-center" style="width: 15%;"> remote_ip  </th>
-	<th class="text-center" style="width: 15%;"> action </th>
-	<th class="text-center" style="width: 15%;"> date  </th>
-	<th class="text-center" style="width: 15%;"> Actions </th>
+	<th class="text-center col-w-15p"> id  </th>
+	<th class="text-center col-w-15p"> user_id  </th>
+	<th class="text-center col-w-15p"> remote_ip  </th>
+	<th class="text-center col-w-15p"> action </th>
+	<th class="text-center col-w-15p"> date  </th>
+	<th class="text-center col-w-15p"> Actions </th>
 
 </tr>
 </thead>

--- a/users/users.php
+++ b/users/users.php
@@ -47,13 +47,13 @@ $all_users = find_all_user();
         <thead>
 <!--     *************************     -->
           <tr>
-            <th class="text-center" style="width: 50px;">ID#</th>
+            <th class="text-center col-w-50">ID#</th>
             <th>Name </th>
             <th>Username</th>
-            <th class="text-center" style="width: 15%;">User Role</th>
-            <th class="text-center" style="width: 10%;">Status</th>
-            <th style="width: 20%;">Last Login</th>
-            <th class="text-center" style="width: 100px;">Actions</th>
+            <th class="text-center col-w-15p">User Role</th>
+            <th class="text-center col-w-10p">Status</th>
+            <th class="col-w-20p">Last Login</th>
+            <th class="text-center col-w-100">Actions</th>
           </tr>
 <!--     *************************     -->
         </thead>


### PR DESCRIPTION
- CSP `style-src` is now `'self'` only — no `'unsafe-inline'`. Combined with the existing `script-src 'self'`, the deployed CSP now bans both `'unsafe-inline'` and `'unsafe-eval'` outright.
- 117 `style="width: X"` attrs across 21 PHP files replaced with 6 `col-w-*` utility classes in `libs/css/main.css`.
- 4 identical `<style>` blocks on print/invoice/report pages extracted to a shared `libs/css/print.css`.
- Test guard added in `tests/SecurityHeadersTest.php` to assert the tightened CSP and lock in the regression boundary.
CSP `style-src` only governs HTML-parsed inline styles (`<style>` blocks and `style=""` attributes). Runtime style mutations via `element.style.x` or jQuery `.css()` go through the JS execution context (`script-src`), so the bundled Bootstrap and jQuery plugins (dropdowns, popovers, tooltips) keep working unchanged.
- `includes/load.php` — `style-src 'self' 'unsafe-inline'` → `style-src 'self'`; comment refreshed.
- `libs/css/main.css` — adds `.col-w-15`, `.col-w-50`, `.col-w-100`, `.col-w-10p`, `.col-w-15p`, `.col-w-20p`.
- `libs/css/print.css` — new shared print stylesheet (extracted from 4 identical inline blocks).
- 4 print pages link `print.css` instead of inlining the block.
- 21 PHP table pages: every `class="X" style="width: Y"` → `class="X col-w-Y"`.
- `tests/SecurityHeadersTest.php` — extends test 7 to also assert no `'unsafe-inline'` and that script-src/style-src are `'self'` only.
- `docs/gap-analysis.md` and the next-steps memo updated.
- [x] `bash tests/run.sh` — 4/4 suites pass locally (AuthTest, CSRFTest, CRUDTest, SecurityHeadersTest).
- [x] Manual: load `/users/index.php` (login page) and `/users/home.php` and confirm the response `Content-Security-Policy` header matches the new value (`default-src 'self'; script-src 'self'; style-src 'self'; …`).
- [ ] After merge, smoke the live deploy: load a few table-heavy pages (`users/users.php`, `products/products.php`, `sales/sales_by_order.php`) and verify column widths render unchanged. Print a sales invoice / order picklist and confirm the print layout still works.
- [ ] CI green on the PR (php -l + full test suite).
🤖 Generated with [Claude Code](https://claude.com/claude-code)