### PR TITLE
chore(hooks): add pre-commit php -l hook (opt-in)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# .githooks/pre-commit
+#
+# Run `php -l` on every staged .php file. Reject the commit if any of them
+# has a parse error. Mirrors the "PHP Lint" job in .github/workflows/ci.yml
+# so syntax errors are caught locally instead of after a push.
+#
+# Enable once per clone with:
+#     bash scripts/install-hooks.sh
+# (which sets `git config core.hooksPath .githooks`).
+
+set -u
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+if ! command -v php >/dev/null 2>&1; then
+    echo -e "${YELLOW}pre-commit: php not on PATH; skipping syntax check.${NC}" >&2
+    exit 0
+fi
+
+mapfile -d '' -t STAGED < <(
+    git diff --cached -z --name-only --diff-filter=ACMR -- '*.php'
+)
+
+if [ ${#STAGED[@]} -eq 0 ]; then
+    exit 0
+fi
+
+errors=0
+for file in "${STAGED[@]}"; do
+    [ -f "$file" ] || continue
+    if ! out=$(php -l "$file" 2>&1); then
+        echo -e "${RED}pre-commit: syntax error in${NC} $file" >&2
+        echo "$out" >&2
+        errors=$((errors + 1))
+    fi
+done
+
+if [ $errors -gt 0 ]; then
+    echo -e "${RED}pre-commit: ${errors} file(s) failed php -l. Commit aborted.${NC}" >&2
+    echo "Fix the errors and re-stage, or bypass with 'git commit --no-verify'." >&2
+    exit 1
+fi
+
+echo -e "${GREEN}pre-commit: php -l clean (${#STAGED[@]} file(s)).${NC}"
+exit 0

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ bash install.sh --reinstall
 
 For manual install, troubleshooting, role-based workflows, and daily operations, see **[docs/setup-and-usage.md](docs/setup-and-usage.md)**.
 
+### Developer hooks (optional)
+
+To run `php -l` on staged PHP files before each commit (same check CI runs):
+
+```bash
+bash scripts/install-hooks.sh
+```
+
+This points `core.hooksPath` at the tracked `.githooks/` directory. Bypass with `git commit --no-verify` if you need to commit despite a parse error.
+
 ---
 
 ## Default accounts

--- a/docs/gap-analysis.md
+++ b/docs/gap-analysis.md
@@ -122,4 +122,4 @@ Most prior-pass items now resolved (see section 4 below). Remaining work:
 1. **Soft-delete refactor** (its own PR) — `deleted_at` columns + `soft_delete_by_id()` + `restore_by_id()` + filter every SELECT. See section 3 above for scope.
 2. **Per-tenant currency** — make `$CURRENCY_CODE` a column in a settings table or `.env` value.
 3. **Browser-level UI tests** — Playwright covering the login → add-product → add-sale → invoice happy path.
-4. **Pre-commit hook** for `php -l` on staged files (the CI catches this on push but pre-commit prevents bad commits).
+4. ~~**Pre-commit hook** for `php -l` on staged files~~ — ✅ ADDED 2026-05-15 — `.githooks/pre-commit` + `scripts/install-hooks.sh`; opt-in per clone (`bash scripts/install-hooks.sh`).

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# scripts/install-hooks.sh
+#
+# Point this clone's git hooks at the tracked .githooks/ directory so the
+# pre-commit php -l check runs locally. Safe to re-run.
+
+set -e
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+git config core.hooksPath .githooks
+echo "core.hooksPath -> $(git config core.hooksPath)"
+echo "Hooks active:"
+ls -1 .githooks


### PR DESCRIPTION
- Adds `.githooks/pre-commit` that runs `php -l` on every staged `.php` file and aborts the commit on a parse error. Mirrors the "PHP Lint" job in `.github/workflows/ci.yml`, so syntax errors surface locally instead of after a push.
- Adds `scripts/install-hooks.sh` to opt-in per clone (`git config core.hooksPath .githooks`).
- README gains a "Developer hooks (optional)" subsection; `docs/gap-analysis.md` item 4 is struck through.
| Staged set | Result |
|---|---|
| 0 `.php` files | exit 0, silent |
| all clean | exit 0, one-line green success |
| any parse error | exit 1, prints offending file + `php -l` output |
| `php` not on PATH | warn, skip (don't block on missing toolchain) |
Bypass with `git commit --no-verify` if intentional.
- [x] Sandbox `git init` repo, run hook against clean file → rc=0 with green message
- [x] Sandbox repo, stage clean + broken file → rc=1, prints "syntax error in b.php" + parse-error detail
- [x] Sandbox repo, stage only a non-php file → rc=0 silent (no work to do)
- [x] Full test suite: `bash tests/run.sh` — 4/4 suites passed
- [ ] Reviewer: run `bash scripts/install-hooks.sh` locally and confirm `core.hooksPath` flips to `.githooks`
🤖 Generated with [Claude Code](https://claude.com/claude-code)