### PR TITLE
feat(settings): admin-editable currency via settings table

### DIFF
--- a/docs/gap-analysis.md
+++ b/docs/gap-analysis.md
@@ -120,6 +120,6 @@ Cross-reference of `docs/*.md` claims against actual code:
 Most prior-pass items now resolved (see section 4 below). Remaining work:
 
 1. **Soft-delete refactor** (its own PR) — `deleted_at` columns + `soft_delete_by_id()` + `restore_by_id()` + filter every SELECT. See section 3 above for scope.
-2. **Per-tenant currency** — make `$CURRENCY_CODE` a column in a settings table or `.env` value.
+2. ~~**Per-tenant currency**~~ — ✅ ADDED 2026-05-15 (single-tenant variant) — migration 004 creates a `settings(setting_key, setting_value)` table; `Settings::get('currency_code', 'USD')` in load.php; admin-only `/users/settings.php` page to edit the value. Per-org/per-user currency still future work and requires a tenancy model.
 3. **Browser-level UI tests** — Playwright covering the login → add-product → add-sale → invoice happy path.
 4. ~~**Pre-commit hook** for `php -l` on staged files~~ — ✅ ADDED 2026-05-15 — `.githooks/pre-commit` + `scripts/install-hooks.sh`; opt-in per clone (`bash scripts/install-hooks.sh`).

--- a/includes/database.php
+++ b/includes/database.php
@@ -223,6 +223,20 @@ class MySqli_DB {
 	}
 
 
+	/**
+	 * Raw mysqli connection. Lets callers run queries that need to handle
+	 * their own errors instead of going through query()/prepare_query(),
+	 * which die() on failure. Used by Settings::load() so a missing
+	 * `settings` table during a migration window falls back to defaults
+	 * instead of taking the whole site down.
+	 *
+	 * @return mysqli
+	 */
+	public function connection() {
+		return $this->con;
+	}
+
+
 	/*--------------------------------------------------------------*/
 	/* Function for while loop
 	/*--------------------------------------------------------------*/

--- a/includes/formatcurrency.php
+++ b/includes/formatcurrency.php
@@ -9,26 +9,26 @@
  */
 
 
-function formatcurrency($floatcurr, $curr = 'USD') {
-
-	/**
-	 * A list of the ISO 4217 currency codes with symbol,format and symbol order
-	 *
-	 * Symbols from
-	 * http://character-code.com/currency-html-codes.php
-	 * http://www.phpclasses.org/browse/file/2054.html
-	 * https://github.com/yiisoft/yii/blob/633e54866d54bf780691baaaa4a1f847e8a07e23/framework/i18n/data/en_us.php
-	 *
-	 * Formats from
-	 * http://www.joelpeterson.com/blog/2011/03/formatting-over-100-currencies-in-php/
-	 *
-	 * Array with key as ISO 4217 currency code
-	 * 0 - Currency Symbol if there's
-	 * 1 - Round
-	 * 2 - Thousands separator
-	 * 3 - Decimal separator
-	 * 4 - 0 = symbol in front OR 1 = symbol after currency
-	 */
+/**
+ * ISO 4217 currency table: symbol, round, thousands sep, decimal sep,
+ * symbol position. Exposed so the admin Settings page can validate
+ * incoming `currency_code` values against the same list that
+ * formatcurrency() uses to render them.
+ *
+ * Array with key as ISO 4217 currency code:
+ *   0 - Currency Symbol if there's
+ *   1 - Round
+ *   2 - Thousands separator
+ *   3 - Decimal separator
+ *   4 - 0 = symbol in front OR 1 = symbol after currency
+ *
+ * @return array<string, array{0:?string,1:int,2:string,3:string,4:int}>
+ */
+function currency_table() {
+	static $currencies = null;
+	if ($currencies !== null) {
+		return $currencies;
+	}
 	$currencies = array(
 		'ARS' => array(NULL, 2, ',', '.', 0),          //  Argentine Peso
 		'AMD' => array(NULL, 2, '.', ',', 0),          //  Armenian Dram
@@ -122,7 +122,32 @@ function formatcurrency($floatcurr, $curr = 'USD') {
 		'VND' => array('&#x20ab;', 0, '', '.', 0),           //  Viet Nam, Dong ₫
 		'ZWD' => array(NULL, 2, '.', ' ', 0),          //  Zimbabwe Dollar
 	);
+	return $currencies;
+}
 
+
+/**
+ * List of supported ISO 4217 currency codes, sorted alphabetically.
+ * Used by the admin Settings page to populate the dropdown and validate
+ * POSTed values.
+ *
+ * @return string[]
+ */
+function supported_currency_codes() {
+	$codes = array_keys(currency_table());
+	sort($codes);
+	return $codes;
+}
+
+
+function formatcurrency($floatcurr, $curr = 'USD') {
+	$currencies = currency_table();
+
+	// Defensive fallback: an unknown code (e.g. left over from a deleted
+	// row) renders as USD rather than throwing on undefined index.
+	if (!isset($currencies[$curr])) {
+		$curr = 'USD';
+	}
 
 	//rupees weird format
 	if ($curr == "INR")

--- a/includes/load.php
+++ b/includes/load.php
@@ -67,12 +67,14 @@ require_once LIB_PATH_INC.'upload.php';
 require_once LIB_PATH_INC.'database.php';
 require_once LIB_PATH_INC.'sql.php';
 require_once LIB_PATH_INC.'formatcurrency.php';
+require_once LIB_PATH_INC.'settings.php';
 
 /*--------------------------------------------------------------*/
-/* Change format of currency used throughout the system
+/* Currency used throughout the system. Sourced from the settings
+/* table (admin-editable via /users/settings.php). Falls back to
+/* 'USD' if the row or table is missing (e.g. pre-migration-004).
 /*--------------------------------------------------------------*/
-$CURRENCY_CODE = 'USD';
-//$CURRENCY_CODE = 'EUR';
+$CURRENCY_CODE = Settings::get('currency_code', 'USD');
 
 
 /*--------------------------------------------------------------*/

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * includes/settings.php
+ *
+ * App-wide single-tenant settings, backed by the `settings(setting_key,
+ * setting_value)` table. Values are loaded once per request and cached in a
+ * static, so repeated Settings::get() calls hit memory, not the DB.
+ *
+ * Falls back to the supplied default if the row (or table) is missing — the
+ * latter case covers the brief window between a deploy and `migrations/004`
+ * being applied.
+ */
+
+class Settings {
+
+    private static $cache = [];
+    private static $loaded = false;
+
+    /**
+     * Read a setting value. Lazy-loads the table on first call.
+     *
+     * @param string $key
+     * @param string|null $default
+     * @return string|null
+     */
+    public static function get($key, $default = null) {
+        if (!self::$loaded) {
+            self::load();
+        }
+        return self::$cache[$key] ?? $default;
+    }
+
+    /**
+     * Upsert a setting value. Updates the in-process cache so subsequent
+     * Settings::get() calls in the same request see the new value.
+     *
+     * @param string $key
+     * @param string $value
+     * @return bool true on success
+     */
+    public static function set($key, $value) {
+        global $db;
+        $stmt = $db->prepare_query(
+            'INSERT INTO `settings` (`setting_key`, `setting_value`) VALUES (?, ?) '
+            . 'ON DUPLICATE KEY UPDATE `setting_value` = VALUES(`setting_value`)',
+            'ss', $key, $value
+        );
+        $stmt->close();
+        self::$cache[$key] = $value;
+        self::$loaded = true;
+        return true;
+    }
+
+    /**
+     * Reset the in-process cache. Tests call this between cases.
+     */
+    public static function clear_cache() {
+        self::$cache = [];
+        self::$loaded = false;
+    }
+
+    /**
+     * Populate the cache from the settings table. Swallows a missing-table
+     * error so a half-migrated deploy still serves traffic on defaults.
+     */
+    private static function load() {
+        global $db;
+        self::$loaded = true;
+        try {
+            $con = $db->connection();
+            $result = $con->query('SELECT `setting_key`, `setting_value` FROM `settings`');
+            if ($result === false) {
+                return;
+            }
+            while ($row = $result->fetch_assoc()) {
+                self::$cache[$row['setting_key']] = $row['setting_value'];
+            }
+            $result->free();
+        } catch (\mysqli_sql_exception $e) {
+            error_log('Settings::load() — settings table unavailable, using defaults: ' . $e->getMessage());
+        }
+    }
+}

--- a/layouts/admin_menu.php
+++ b/layouts/admin_menu.php
@@ -68,6 +68,7 @@
       <li><a href="../users/group.php">Manage Groups</a> </li>
       <li><a href="../users/users.php">Manage Users</a> </li>
       <li><a href="../users/log.php">System Log</a> </li>
+      <li><a href="../users/settings.php">Settings</a> </li>
    </ul>
   </li>
 

--- a/migrations/004_settings_table.down.sql
+++ b/migrations/004_settings_table.down.sql
@@ -1,0 +1,13 @@
+-- Migration 004 reverse — Drop the settings table.
+--
+-- Restores the prior state where currency_code lived as a hardcoded
+-- `$CURRENCY_CODE = 'USD'` in includes/load.php. After running this, the
+-- code in load.php that reads from settings must also be reverted, or it
+-- will fall back to its default ('USD') silently.
+
+SELECT 'Dropping settings table...' AS step;
+
+DROP TABLE IF EXISTS `settings`;
+
+SELECT 'After reverse migration:' AS step;
+SHOW TABLES LIKE 'settings';

--- a/migrations/004_settings_table.up.sql
+++ b/migrations/004_settings_table.up.sql
@@ -1,0 +1,29 @@
+-- Migration 004 — App settings table (single-tenant).
+--
+-- Replaces the hardcoded `$CURRENCY_CODE = 'USD'` in includes/load.php with
+-- a DB-backed value editable from an admin-only Settings page. Single-tenant:
+-- one row per setting, applies to the whole deployment.
+--
+-- Schema: key/value strings with an updated_at audit column. Seeds the
+-- currency_code row with 'USD' so behaviour is unchanged immediately after
+-- the migration runs.
+--
+-- Reverse: see 004_settings_table.down.sql
+
+SELECT 'Creating settings table...' AS step;
+
+CREATE TABLE IF NOT EXISTS `settings` (
+  `setting_key` varchar(64) NOT NULL,
+  `setting_value` varchar(255) NOT NULL,
+  `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`setting_key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+SELECT 'Seeding currency_code = USD...' AS step;
+
+INSERT INTO `settings` (`setting_key`, `setting_value`)
+VALUES ('currency_code', 'USD')
+ON DUPLICATE KEY UPDATE `setting_value` = `setting_value`;
+
+SELECT 'After migration:' AS step;
+SELECT `setting_key`, `setting_value`, `updated_at` FROM `settings`;

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -39,4 +39,7 @@ sudo mysql inventory < migrations/001_quantity_int.down.sql
 
 | # | Name | Forward | Reverse | Status |
 |---|------|---------|---------|--------|
-| 001 | `quantity_int` | Convert `products.quantity` and `stock.quantity` from VARCHAR(50) to INT | Restore to VARCHAR(50) | Pending — see gap-analysis.md |
+| 001 | `quantity_int` | Convert `products.quantity` and `stock.quantity` from VARCHAR(50) to INT | Restore to VARCHAR(50) | Applied 2026-05-14 |
+| 002 | `failed_logins` | Create `failed_logins` rate-limit table | Drop table | Applied 2026-05-14 |
+| 003 | `log_user_fk` | FK `log.user_id → users.id` ON DELETE SET NULL | Drop FK, revert column to signed | Applied 2026-05-15 |
+| 004 | `settings_table` | Create `settings` table, seed `currency_code='USD'` | Drop `settings` table | New — see PR for currency feature |

--- a/schema.sql
+++ b/schema.sql
@@ -215,6 +215,26 @@ INSERT INTO `user_groups` (`id`, `group_name`, `group_level`, `group_status`) VA
 (2, 'Supervisor', 2, 1),
 (3, 'User', 3, 1);
 
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `settings` (app-wide single-tenant settings)
+--
+
+CREATE TABLE `settings` (
+  `setting_key` varchar(64) NOT NULL,
+  `setting_value` varchar(255) NOT NULL,
+  `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`setting_key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+--
+-- Dumping data for table `settings`
+--
+
+INSERT INTO `settings` (`setting_key`, `setting_value`) VALUES
+('currency_code', 'USD');
+
 --
 -- Indexes for dumped tables
 --

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -110,7 +110,10 @@ test('currency_code round-trip changes formatcurrency() output', function () {
     check($code === 'EUR', "expected EUR, got: $code");
 
     $eur = formatcurrency(1234.56, $code);
-    check(str_contains($eur, 'EUR') || str_contains($eur, '€'), "EUR output looks wrong: $eur");
+    // formatcurrency() emits HTML entities (e.g. &euro;) for symbols, so
+    // decode before substring-matching against the literal char.
+    $decoded = html_entity_decode($eur, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    check(str_contains($decoded, 'EUR') || str_contains($decoded, '€'), "EUR output looks wrong: $eur");
     echo "       [EUR sample: $eur]\n";
 
     // Restore to the canonical seeded value.

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * tests/SettingsTest.php
+ *
+ * Integration tests for the Settings class + supported-currency helpers.
+ * Requires a live database with migration 004 applied.
+ *
+ * Touches the `settings` table directly; restores the seeded
+ * currency_code = 'USD' row at the end so subsequent runs are
+ * deterministic.
+ */
+
+require_once __DIR__ . '/bootstrap.php';
+
+$pass = 0;
+$fail = 0;
+
+function test(string $name, callable $fn): void
+{
+    global $pass, $fail;
+    try {
+        $fn();
+        $pass++;
+        echo "  PASS: $name\n";
+    } catch (Throwable $e) {
+        $fail++;
+        echo "  FAIL: $name — " . $e->getMessage() . "\n";
+    }
+}
+
+function check(bool $cond, string $msg): void
+{
+    if (!$cond) {
+        throw new RuntimeException($msg);
+    }
+}
+
+echo "=== SettingsTest ===\n\n";
+
+// Skip gracefully if the settings table doesn't exist locally
+// (migration 004 not yet applied). CI imports schema.sql which already
+// contains the table, so this only ever skips on a dev box where the
+// admin hasn't run the migration.
+$settings_exists = false;
+try {
+    global $db;
+    $r = $db->connection()->query("SHOW TABLES LIKE 'settings'");
+    $settings_exists = ($r !== false && $r->num_rows > 0);
+    if ($r) {
+        $r->free();
+    }
+} catch (\Throwable $e) {
+    $settings_exists = false;
+}
+if (!$settings_exists) {
+    echo "  SKIPPED: `settings` table not present.\n";
+    echo "  Apply migration 004 to enable these tests:\n";
+    echo "    sudo mysql inventory < migrations/004_settings_table.up.sql\n";
+    echo "\n---\nResults: 0 passed, 0 failed (suite skipped)\n";
+    exit(0);
+}
+
+// 1. supported_currency_codes() returns a sorted, non-empty list that
+//    includes USD.
+test('supported_currency_codes() returns sorted list including USD', function () {
+    $codes = supported_currency_codes();
+    check(is_array($codes) && count($codes) > 50, 'expected >50 supported currencies');
+    check(in_array('USD', $codes, true), 'USD missing from supported list');
+    $sorted = $codes;
+    sort($sorted);
+    check($codes === $sorted, 'codes are not in sorted order');
+    echo "       [{$codes[0]} ... {$codes[count($codes)-1]}, " . count($codes) . " total]\n";
+});
+
+// 2. Default fallback when key absent and table reachable.
+test('Settings::get() returns default for unknown key', function () {
+    global $db;
+    Settings::clear_cache();
+    // ensure the test key doesn't exist
+    $stmt = $db->prepare_query('DELETE FROM `settings` WHERE `setting_key` = ?', 's', 'HARNESS_unknown_key');
+    $stmt->close();
+    Settings::clear_cache();
+    $v = Settings::get('HARNESS_unknown_key', 'fallback-value');
+    check($v === 'fallback-value', 'expected fallback-value, got: ' . var_export($v, true));
+});
+
+// 3. set() upserts and updates cache.
+test('Settings::set() persists and updates cache', function () {
+    Settings::clear_cache();
+    Settings::set('HARNESS_test_key', 'first-value');
+    check(Settings::get('HARNESS_test_key') === 'first-value', 'first set did not stick');
+
+    // Re-read with a fresh cache to confirm it really hit the DB.
+    Settings::clear_cache();
+    check(Settings::get('HARNESS_test_key') === 'first-value', 'value did not survive cache flush');
+
+    // Update — same key, new value — should overwrite, not duplicate.
+    Settings::set('HARNESS_test_key', 'second-value');
+    Settings::clear_cache();
+    check(Settings::get('HARNESS_test_key') === 'second-value', 'update did not overwrite');
+});
+
+// 4. Round-trip with the production key (currency_code) — sets, reads
+//    back, formats a number through formatcurrency() and confirms the
+//    output reflects the chosen code's symbol/format.
+test('currency_code round-trip changes formatcurrency() output', function () {
+    Settings::set('currency_code', 'EUR');
+    Settings::clear_cache();
+    $code = Settings::get('currency_code', 'USD');
+    check($code === 'EUR', "expected EUR, got: $code");
+
+    $eur = formatcurrency(1234.56, $code);
+    check(str_contains($eur, 'EUR') || str_contains($eur, '€'), "EUR output looks wrong: $eur");
+    echo "       [EUR sample: $eur]\n";
+
+    // Restore to the canonical seeded value.
+    Settings::set('currency_code', 'USD');
+    Settings::clear_cache();
+});
+
+// 5. formatcurrency() with an unknown code falls back to USD instead of
+//    throwing.
+test('formatcurrency() with unknown code falls back to USD', function () {
+    $out = formatcurrency(100, 'ZZZ');
+    check($out === '$100.00', "expected USD fallback, got: $out");
+});
+
+// Cleanup: drop the harness row(s) so the table only contains the seed.
+test('Cleanup HARNESS rows', function () {
+    global $db;
+    $stmt = $db->prepare_query('DELETE FROM `settings` WHERE `setting_key` LIKE ?', 's', 'HARNESS_%');
+    $stmt->close();
+});
+
+echo "\n---\nResults: $pass passed, $fail failed\n";
+exit($fail > 0 ? 1 : 0);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -42,6 +42,10 @@ if (!getenv('TESTS_NO_DB')) {
     require_once LIB_PATH_INC . 'sql.php';
 }
 
+// Load Settings (lazy — only queries the DB when get() is called)
+require_once LIB_PATH_INC . 'settings.php';
+require_once LIB_PATH_INC . 'formatcurrency.php';
+
 // Session stub for CLI testing (no HTTP headers)
 if (php_sapi_name() === 'cli') {
     $_SESSION = [];

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -69,13 +69,14 @@ fi
 if [ "$DB_OK" -eq 1 ]; then
     run_test "tests/AuthTest.php" "Authentication (integration)"
     run_test "tests/CRUDTest.php" "CRUD Operations (integration)"
+    run_test "tests/SettingsTest.php" "Settings (integration)"
 else
     echo "--- Authentication (integration) ---"
     echo "  SKIPPED: Database not accessible."
     echo "  Configure .env with valid credentials to enable integration tests."
     echo ""
-    SKIPPED=$((SKIPPED + 2))
-    TOTAL=$((TOTAL + 2))
+    SKIPPED=$((SKIPPED + 3))
+    TOTAL=$((TOTAL + 3))
 fi
 
 # HTTP-dependent test: only runs if a web server is reachable.

--- a/users/settings.php
+++ b/users/settings.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * users/settings.php
+ *
+ * Admin-only Settings page. Currently exposes one knob — the app-wide
+ * currency code — backed by the `settings` table. Designed so additional
+ * key/value rows can be added with one extra form field + Settings::set()
+ * call here, no schema change.
+ */
+
+
+$page_title = 'Settings';
+require_once '../includes/load.php';
+page_require_level(1);
+
+$current_currency = Settings::get('currency_code', 'USD');
+$supported = supported_currency_codes();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!verify_csrf()) {
+        $session->msg('d', 'Invalid or missing security token.');
+        redirect('../users/settings.php', false);
+    }
+
+    $posted = isset($_POST['currency_code']) ? trim($_POST['currency_code']) : '';
+    if (!in_array($posted, $supported, true)) {
+        $session->msg('d', 'Unsupported currency code: ' . htmlspecialchars($posted, ENT_QUOTES, 'UTF-8'));
+        redirect('../users/settings.php', false);
+    }
+
+    Settings::set('currency_code', $posted);
+    $session->msg('s', 'Currency updated to ' . htmlspecialchars($posted, ENT_QUOTES, 'UTF-8') . '.');
+    redirect('../users/settings.php', false);
+}
+?>
+<?php include_once '../layouts/header.php'; ?>
+
+<div class="row">
+   <div class="col-md-12">
+      <?php echo display_msg($msg); ?>
+   </div>
+</div>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <strong>
+          <span class="glyphicon glyphicon-cog"></span> Application Settings
+        </strong>
+      </div>
+      <div class="panel-body">
+        <form method="post" action="../users/settings.php">
+          <?php echo csrf_field(); ?>
+
+          <div class="form-group">
+            <label for="currency_code" class="control-label">Currency Code</label>
+            <select name="currency_code" id="currency_code" class="form-control">
+              <?php foreach ($supported as $code): ?>
+                <option value="<?php echo htmlspecialchars($code, ENT_QUOTES, 'UTF-8'); ?>"
+                  <?php echo ($code === $current_currency) ? 'selected' : ''; ?>>
+                  <?php echo htmlspecialchars($code, ENT_QUOTES, 'UTF-8'); ?>
+                </option>
+              <?php endforeach; ?>
+            </select>
+            <p class="help-block">
+              ISO 4217 code. Applies to every monetary value rendered by the system
+              (invoices, picklists, sales/stock reports, dashboards). Sample:
+              <strong><?php echo formatcurrency(1234.56, $current_currency); ?></strong>.
+            </p>
+          </div>
+
+          <button type="submit" class="btn btn-primary">Save</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+
+<?php include_once '../layouts/footer.php'; ?>


### PR DESCRIPTION
Replaces the hardcoded `$CURRENCY_CODE = 'USD'` in `includes/load.php` with a DB-backed value an admin can change from a new Settings page. Single-tenant — one currency per deployment.
- New `settings(setting_key, setting_value, updated_at)` table (migration 004 + schema.sql).
- `Settings::get/set` with per-request cache (`includes/settings.php`); gracefully degrades to defaults if the table is missing (e.g. brief window between deploy and migration apply).
- Admin-only `/users/settings.php` page: CSRF-protected dropdown of the ~91 ISO 4217 codes `formatcurrency()` already supports, with a live sample render of `1234.56` at the chosen code.
- `formatcurrency.php` refactor: the currency table is now exposed through a memoized `currency_table()` helper + `supported_currency_codes()` so the form validates against the exact list the renderer knows. Unknown codes fall back to USD instead of throwing on undefined-index.
- New `SettingsTest.php` integration suite; skips cleanly when the local DB doesn't have the table yet.
After merge, on each existing deployment:
```bash
sudo mysqldump --single-transaction inventory > inventory-pre-004.sql
sudo mysql inventory < migrations/004_settings_table.up.sql
```
CI doesn't need this — `schema.sql` is the canonical fresh state and already contains the table.
- [x] `bash tests/run.sh` — 5/5 suites pass locally (SettingsTest skipped because migration not applied here)
- [x] `php -l` clean across all modified PHP (caught by the new pre-commit hook from PR #29)
- [x] `formatcurrency()` regression: unknown code returns `$100.00` USD instead of warning
- [x] CSP smoke: live deploy returns `style-src 'self'`, login page has 0 inline styles (pre-existing behaviour unchanged)
- [ ] **Reviewer:** apply migration 004 on a staging DB, change currency to EUR via the new page, confirm an existing invoice + a daily-sales report render as €
- [ ] **Reviewer:** confirm CI's "Test Suite" job runs `SettingsTest` against the schema.sql-imported `settings` table (i.e. it does NOT skip in CI)
- [ ] **Reviewer:** non-admin (group_level 2 or 3) hitting `/users/settings.php` is redirected by `page_require_level(1)`
Per-organization / per-user currency requires a tenancy model the codebase doesn't have. Captured in `docs/gap-analysis.md` as a follow-up.
🤖 Generated with [Claude Code](https://claude.com/claude-code)