### PR TITLE
fix(csrf): close form action quote before csrf_field on 8 pages

### DIFF
--- a/products/edit_category.php
+++ b/products/edit_category.php
@@ -58,8 +58,8 @@ $req_field = array('category-name');
         </strong>
        </div>
        <div class="panel-body">
-         <form method="post" action="../products/edit_category.php?id=<?php echo (int)$category['id'];?>
-              <?php echo csrf_field(); ?>">
+         <form method="post" action="../products/edit_category.php?id=<?php echo (int)$category['id'];?>">
+              <?php echo csrf_field(); ?>
            <div class="form-group">
                <input type="text" class="form-control" name="category-name" value="<?php echo ucfirst($category['name']);?>">
            </div>

--- a/products/edit_product.php
+++ b/products/edit_product.php
@@ -95,8 +95,8 @@ $req_fields = array('product-title', 'product-category', 'product-quantity', 'co
         </div>
         <div class="panel-body">
          <div class="col-md-12">
-           <form method="post" action="../products/edit_product.php?id=<?php echo (int)$product['id'] ?>
-              <?php echo csrf_field(); ?>">
+           <form method="post" action="../products/edit_product.php?id=<?php echo (int)$product['id'] ?>">
+              <?php echo csrf_field(); ?>
               <div class="form-group">
                 <div class="input-group">
                   <span class="input-group-addon">

--- a/sales/add_sale_by_search.php
+++ b/sales/add_sale_by_search.php
@@ -71,8 +71,8 @@ $all_categories = find_all('categories');
 <div class="row">
   <div class="col-md-6">
     <?php echo display_msg($msg); ?>
-    <form method="post" action="../sales/add_sale_by_search.php?id=<?php echo $order_id; ?>
-              <?php echo csrf_field(); ?>">
+    <form method="post" action="../sales/add_sale_by_search.php?id=<?php echo $order_id; ?>">
+              <?php echo csrf_field(); ?>
         <div class="form-group">
           <div class="input-group">
             <span class="input-group-btn">
@@ -139,8 +139,8 @@ if (isset($_POST['search']) && strlen($_POST['search'])) {
 		if ( $added_to_order == false ) {
 
 ?>
-        <form method="post" action="../sales/add_sale_by_search.php?id=<?php echo $order_id; ?>
-              <?php echo csrf_field(); ?>">
+        <form method="post" action="../sales/add_sale_by_search.php?id=<?php echo $order_id; ?>">
+              <?php echo csrf_field(); ?>
 
 <tr>
 <td id="s_name">

--- a/sales/add_sale_to_order.php
+++ b/sales/add_sale_to_order.php
@@ -162,8 +162,8 @@ foreach ( $products_available as $product ) {
 	if ( $added_to_order == false ) {
 
 ?>
-        <form method="post" action="../sales/add_sale_to_order.php?id=<?php echo $order_id; ?>
-              <?php echo csrf_field(); ?>">
+        <form method="post" action="../sales/add_sale_to_order.php?id=<?php echo $order_id; ?>">
+              <?php echo csrf_field(); ?>
 
 <tr>
 <td id="s_name">

--- a/sales/edit_order.php
+++ b/sales/edit_order.php
@@ -84,8 +84,8 @@ $req_fields = array('customer-name', 'paymethod' );
         </strong>
        </div>
        <div class="panel-body">
-         <form method="post" action="../sales/edit_order.php?id=<?php echo (int)$order['id'];?>
-              <?php echo csrf_field(); ?>">
+         <form method="post" action="../sales/edit_order.php?id=<?php echo (int)$order['id'];?>">
+              <?php echo csrf_field(); ?>
            <div class="form-group">
                <input type="text" class="form-control" name="customer-name" value="<?php echo ucfirst($order['customer']);?>">
            </div>

--- a/users/edit_account.php
+++ b/users/edit_account.php
@@ -89,8 +89,8 @@ $req_fields = array('name', 'username' );
         <span>Edit My Account</span>
       </div>
       <div class="panel-body">
-          <form method="post" action="../users/edit_account.php?id=<?php echo (int)$user['id'];?>
-              <?php echo csrf_field(); ?>" class="clearfix">
+          <form method="post" action="../users/edit_account.php?id=<?php echo (int)$user['id'];?>" class="clearfix">
+              <?php echo csrf_field(); ?>
             <div class="form-group">
                   <label for="name" class="control-label">Name</label>
                   <input type="name" class="form-control" name="name" value="<?php echo h(ucwords($user['name'])); ?>">

--- a/users/edit_category.php
+++ b/users/edit_category.php
@@ -58,8 +58,8 @@ $req_field = array('category-name');
         </strong>
        </div>
        <div class="panel-body">
-         <form method="post" action="../users/edit_categorie.php?id=<?php echo (int)$category['id'];?>
-              <?php echo csrf_field(); ?>">
+         <form method="post" action="../users/edit_categorie.php?id=<?php echo (int)$category['id'];?>">
+              <?php echo csrf_field(); ?>
            <div class="form-group">
                <input type="text" class="form-control" name="category-name" value="<?php echo ucfirst($category['name']);?>">
            </div>

--- a/users/edit_group.php
+++ b/users/edit_group.php
@@ -66,8 +66,8 @@ $req_fields = array('group-name', 'group-level');
 <!--     *************************     -->
      </div>
      <?php echo display_msg($msg); ?>
-      <form method="post" action="../users/edit_group.php?id=<?php echo (int)$e_group['id'];?>
-              <?php echo csrf_field(); ?>" class="clearfix">
+      <form method="post" action="../users/edit_group.php?id=<?php echo (int)$e_group['id'];?>" class="clearfix">
+              <?php echo csrf_field(); ?>
 <!--     *************************     -->
         <div class="form-group">
               <label for="name" class="control-label">Group Name</label>


### PR DESCRIPTION
Nine `<form method=\"post\" action=\"...?>` openings on 8 edit pages dropped the closing `\"` of the action attribute, then placed `<?php echo csrf_field(); ?>` on the next line and closed the quote *after* that. After PHP rendered, the browser saw:
```
<form method=\"post\" action=\"../path.php?id=42
              <input type=\"hidden\" name=\"csrf_token\" value=\"...\">\"
      class=\"clearfix\">
```
The action attribute terminated at the next `\"` (the `\"hidden\"` of the csrf input), so `name=\"csrf_token\"` and `value=\"...\"` became attributes of the `<form>` element instead of a real hidden input. The CSRF token was never submitted; every POST failed `verify_csrf()` and bounced through the redirect path, rendering these edit screens effectively unusable for their intended action.
Affected pages (one form each unless noted):
- `users/edit_group.php`
- `users/edit_account.php`
- `users/edit_category.php`
- `products/edit_category.php`
- `products/edit_product.php`
- `sales/edit_order.php`
- `sales/add_sale_by_search.php` (**two** forms in this file)
- `sales/add_sale_to_order.php`
Fix is mechanical and identical at every site: close the action attribute on its own line, then move `<?php echo csrf_field(); ?>` to the next line inside the form body, matching the already-correct pattern in `users/edit_user.php:116-117`.
Found while reviewing follow-ups from PR #30 (the bad pattern was originally captured as item 4 of \`next_steps_inventory.md\`).
- [x] \`php -l\` clean on all 8 touched files
- [x] Pre-commit \`php -l\` hook (PR #29) green on the staged set
- [x] Full local suite: \`bash tests/run.sh\` — 5/5 suites, 43 tests pass
- [ ] CI green
- [ ] Live smoke after merge: edit a user-group on the deployed instance, save, confirm 200 + success flash (not the \"Invalid or missing security token\" redirect loop)
🤖 Generated with [Claude Code](https://claude.com/claude-code)