### PR TITLE
fix(forms): point edit_category form to edit_category.php

### DIFF
--- a/users/edit_category.php
+++ b/users/edit_category.php
@@ -58,7 +58,7 @@ $req_field = array('category-name');
         </strong>
        </div>
        <div class="panel-body">
-         <form method="post" action="../users/edit_categorie.php?id=<?php echo (int)$category['id'];?>">
+         <form method="post" action="../users/edit_category.php?id=<?php echo (int)$category['id'];?>">
               <?php echo csrf_field(); ?>
            <div class="form-group">
                <input type="text" class="form-control" name="category-name" value="<?php echo ucfirst($category['name']);?>">


### PR DESCRIPTION
- users/edit_category.php:61 posted to `../users/edit_categorie.php` — a file that does not exist. Until PR #31 closed the action attribute, the broken CSRF rendering masked the path bug because the form failed `verify_csrf()` before the bad action was ever followed. Now that PR #31 has shipped and the form actually submits, the typo would surface as a 404 on save.
- The page already self-handles POST at users/edit_category.php:25-44, so the correct target is the file itself.
- [x] `php -l users/edit_category.php` clean
- [x] `bash tests/run.sh` — 5/5 suites, 43 tests pass
- [x] `grep -rn "edit_categorie" --include="*.php" .` returns no matches
- [ ] Smoke-test on staging: edit a category, verify it saves and redirects to `category.php` with a success message
Follow-up to #31.