### PR TITLE
chore(precommit): guard unclosed form action + ignore DB dumps

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,9 +2,17 @@
 #
 # .githooks/pre-commit
 #
-# Run `php -l` on every staged .php file. Reject the commit if any of them
-# has a parse error. Mirrors the "PHP Lint" job in .github/workflows/ci.yml
-# so syntax errors are caught locally instead of after a push.
+# 1. Run `php -l` on every staged .php file. Reject the commit if any of
+#    them has a parse error. Mirrors the "PHP Lint" job in
+#    .github/workflows/ci.yml so syntax errors are caught locally instead
+#    of after a push.
+#
+# 2. Guard against the unclosed-form-action-attribute regression class
+#    fixed in PR #31 (commit 56a730b). When a `<form ... action="...?>`
+#    tag drops the closing `"` before `csrf_field()` on the next line,
+#    the browser silently absorbs the CSRF hidden input into the action
+#    URL and the form never submits its token. Catch the pattern at
+#    commit time so it doesn't slip in again.
 #
 # Enable once per clone with:
 #     bash scripts/install-hooks.sh
@@ -46,5 +54,26 @@ if [ $errors -gt 0 ]; then
     exit 1
 fi
 
-echo -e "${GREEN}pre-commit: php -l clean (${#STAGED[@]} file(s)).${NC}"
+# Guard against unclosed action="..." on <form ... > lines (PR #31 regression).
+# An unclosed action quote swallows the next-line CSRF hidden input into the
+# action URL, breaking verify_csrf() on every POST.
+form_hits=0
+for file in "${STAGED[@]}"; do
+    [ -f "$file" ] || continue
+    if matches=$(grep -nE 'action="[^"]*$' "$file"); then
+        echo -e "${RED}pre-commit: unclosed action=\" in${NC} $file" >&2
+        echo "$matches" >&2
+        form_hits=$((form_hits + 1))
+    fi
+done
+
+if [ $form_hits -gt 0 ]; then
+    echo -e "${RED}pre-commit: ${form_hits} file(s) have an action attribute that does not close on the same line.${NC}" >&2
+    echo "This is the PR #31 bug class: csrf_field() on the next line gets absorbed into the action URL." >&2
+    echo "Close the quote on the <form> line, then place csrf_field() inside the form body." >&2
+    echo "Bypass with 'git commit --no-verify' only if you are certain this is intentional." >&2
+    exit 1
+fi
+
+echo -e "${GREEN}pre-commit: php -l clean + form-action guard clean (${#STAGED[@]} file(s)).${NC}"
 exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 .DS_Store
 Thumbs.db
 .remember/
+
+# Pre-migration DB dumps produced by the deploy step in migrations/README.md
+# (e.g. `mysqldump ... > inventory-pre-004.sql`). Contain real data.
+inventory-pre-*.sql


### PR DESCRIPTION
Two follow-ups to #31.
1. **Pre-commit guard against the PR #31 bug class.** `.githooks/pre-commit` now greps staged PHP files for `action="[^"]*$` — an action attribute that does not close its quote before end-of-line. If a match is found, the commit aborts with a message that points back to the bug class (next-line `csrf_field()` gets absorbed into the action URL, breaking `verify_csrf()`).
2. **`.gitignore` the migration backup dumps.** `inventory-pre-*.sql` is the naming used by the deploy step in `migrations/README.md` (`mysqldump > inventory-pre-004.sql`). Two such files were already sitting untracked from the 003 + 004 deploys. They contain real data; they should never be committed.
Tested against the pre-PR-#31 versions of all 8 affected files. Catches all 9 known buggy occurrences, zero false positives on the current tree:
| file (pre-fix) | hits |
|---|---|
| `users/edit_group.php` | 1 |
| `users/edit_account.php` | 1 |
| `users/edit_category.php` | 1 |
| `products/edit_category.php` | 1 |
| `products/edit_product.php` | 1 |
| `sales/edit_order.php` | 1 |
| `sales/add_sale_by_search.php` | 2 |
| `sales/add_sale_to_order.php` | 1 |
| **post-fix `main`** | **0** |
`--no-verify` remains available for the rare legitimate multi-line attribute.
- [x] `bash -n .githooks/pre-commit` — syntax OK
- [x] Synthetic bad-file scan — guard fires
- [x] `grep -rnE 'action="[^"]*$' --include='*.php' .` — 0 hits on current tree
- [x] `git check-ignore -v inventory-pre-003.sql inventory-pre-004.sql` — both matched by the new rule
- [x] `bash tests/run.sh` — 5/5 suites, 43 tests pass