### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: PHP Lint


### PR DESCRIPTION
Potential fix for [https://github.com/bitsandbots/inventory/security/code-scanning/2](https://github.com/bitsandbots/inventory/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root so it applies to both `lint` and `test` jobs without changing behavior. The minimal required permission here is:

- `contents: read`

This supports `actions/checkout@v4` and keeps token scope least-privileged.  
Edit `.github/workflows/ci.yml` near the top-level keys: insert `permissions:` between `on:` and `jobs:` (or anywhere at root level).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
