### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: PHP Lint


### PR DESCRIPTION
Potential fix for [https://github.com/bitsandbots/inventory/security/code-scanning/1](https://github.com/bitsandbots/inventory/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege token access.  
Best fix here (without changing behavior) is to set:

- `permissions:`
  - `contents: read`

Place this after the `on:` trigger block and before `jobs:`. This satisfies checkout needs and keeps token scope minimal for lint/test execution.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
