### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/libs/js/functions.js
+++ b/libs/js/functions.js
@@ -6,7 +6,7 @@ $(function () {
     $(document).on('click', '[data-close-target]', function (e) {
         e.preventDefault();
         var sel = $(this).attr('data-close-target');
-        var $el = $(sel);
+        var $el = $($.find(sel));
         if ($el.css('display') === 'none') {
             $el.css('display', 'block');
         } else {


### PR DESCRIPTION
Potential fix for [https://github.com/bitsandbots/inventory/security/code-scanning/3](https://github.com/bitsandbots/inventory/security/code-scanning/3)

General fix: avoid passing untrusted DOM text into APIs that may parse HTML. Use an API that treats input strictly as a CSS selector.

Best fix here: in `libs/js/functions.js`, replace `$(sel)` with `$.find(sel)` wrapped by `$()` so the result remains a jQuery object:

- Current vulnerable code (lines 8–9):
  - `var sel = $(this).attr('data-close-target');`
  - `var $el = $(sel);`
- Safe replacement:
  - keep `sel` as-is
  - change to `var $el = $($.find(sel));`

This keeps existing functionality (finding target elements and toggling display) while ensuring no HTML parsing occurs from `sel`. No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
