### PR TITLE
fix(tenancy): post-smoke hotfixes — ROLE_ADMIN + schema seed

### DIFF
--- a/includes/sql.php
+++ b/includes/sql.php
@@ -1455,6 +1455,13 @@ function monthlySales($year) {
 
 
 /*--------------------------------------------------------------*/
+/* User level constants
+/*--------------------------------------------------------------*/
+
+if (!defined('ROLE_ADMIN')) {
+	define('ROLE_ADMIN', 1); // group_level 1 = Admin (bypasses org-membership checks)
+}
+
 /* Login rate limiting
 /*--------------------------------------------------------------*/
 

--- a/schema.sql
+++ b/schema.sql
@@ -325,6 +325,15 @@ CREATE TABLE `org_members` (
 INSERT INTO `orgs` (`id`, `name`, `slug`) VALUES
 (1, 'Default Organization', 'default');
 
+--
+-- Dumping data for table `org_members`
+--
+
+INSERT INTO `org_members` (`org_id`, `user_id`, `role`) VALUES
+(1, 1, 'owner'),
+(1, 2, 'admin'),
+(1, 3, 'member');
+
 -- --------------------------------------------------------
 
 --


### PR DESCRIPTION
Two bugs found during PR #35 smoke test on a fresh install:
- **`ROLE_ADMIN` undefined fatal error** — `page_require_level()` referenced the constant before it was defined, causing a 500 on every page after login. Fixed by adding `define('ROLE_ADMIN', 1)` near the other constants in `includes/sql.php`.
- **Empty `org_members` on fresh install** — `schema.sql` seeded `users` and `orgs` but not `org_members`, blocking login for all users on a clean install. Fixed by adding the three default user rows to the seed data.
- [x] Login as `admin / admin` → home loads (previously 500)
- [x] Create product → appears in list
- [x] Create order with line item → visible in orders
- [x] Log out cleanly
- [x] CSP header present, no `unsafe-*`
- [x] Fresh install from `schema.sql` → all three users can log in without manual backfill