### PR TITLE
fix(sql): hoist constants before require_once load.php

### DIFF
--- a/includes/sql.php
+++ b/includes/sql.php
@@ -5,6 +5,18 @@
  * @package default
  */
 
+// Constants must be defined before require_once 'load.php' because load.php
+// can call prune_failed_logins() and page_require_level() via audit hooks,
+// which reference these constants before the rest of this file has loaded.
+if (!defined('ROLE_ADMIN')) {
+	define('ROLE_ADMIN', 1); // group_level 1 = Admin (bypasses org-membership checks)
+}
+if (!defined('LOGIN_MAX_ATTEMPTS')) {
+	define('LOGIN_MAX_ATTEMPTS', 5);
+}
+if (!defined('LOGIN_WINDOW_SECONDS')) {
+	define('LOGIN_WINDOW_SECONDS', 900); // 15 minutes
+}
 
 require_once 'load.php';
 
@@ -1455,24 +1467,8 @@ function monthlySales($year) {
 
 
 /*--------------------------------------------------------------*/
-/* User level constants
-/*--------------------------------------------------------------*/
-
-if (!defined('ROLE_ADMIN')) {
-	define('ROLE_ADMIN', 1); // group_level 1 = Admin (bypasses org-membership checks)
-}
-
 /* Login rate limiting
 /*--------------------------------------------------------------*/
-
-// Maximum failed attempts allowed per IP within the window before lockout.
-if (!defined('LOGIN_MAX_ATTEMPTS')) {
-	define('LOGIN_MAX_ATTEMPTS', 5);
-}
-// Lockout window in seconds.
-if (!defined('LOGIN_WINDOW_SECONDS')) {
-	define('LOGIN_WINDOW_SECONDS', 900); // 15 minutes
-}
 
 /**
  * Count failed logins from the given IP within the rate-limit window.


### PR DESCRIPTION
- `ROLE_ADMIN`, `LOGIN_MAX_ATTEMPTS`, and `LOGIN_WINDOW_SECONDS` were defined late in `sql.php` (after line 1458).
- `sql.php` line 9 does `require_once 'load.php'`, which can call `prune_failed_logins()` and `page_require_level()` via audit hooks *before* `sql.php` finishes loading.
- This caused fatal `Undefined constant` errors when TenancyTest was run as a standalone process (fresh PHP process, no pre-loaded constants from a prior test).
- Fix: moved all three `define()` blocks to the top of `sql.php`, before the `require_once`.
- [x] `bash tests/run.sh` → 7/7 suites, 62 tests passed
- [x] `php tests/TenancyTest.php` → 34/34 passed (standalone, fresh process)
- [x] `php -l includes/sql.php` → no syntax errors