### PR TITLE
refactor(auth): named role constants for page_require_level (PR3)

### DIFF
--- a/customers/add_customer.php
+++ b/customers/add_customer.php
@@ -9,7 +9,7 @@
 $page_title = 'Add Customer';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(2);
+page_require_level(ROLE_SUPERVISOR);
 
 if (!verify_csrf()) { $session->msg('d', 'Invalid or missing security token.'); redirect($_SERVER['HTTP_REFERER'] ?? 'index.php', false); }
   if (isset($_POST['add_customer'])) {

--- a/customers/customers.php
+++ b/customers/customers.php
@@ -12,7 +12,7 @@
 $page_title = 'All Customers';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 
 $all_customers = find_all('customers');
 

--- a/customers/delete_customer.php
+++ b/customers/delete_customer.php
@@ -8,7 +8,7 @@
 
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(2);
+page_require_level(ROLE_SUPERVISOR);
 if (!verify_get_csrf()) { $session->msg('d', 'Invalid or missing security token.'); redirect($_SERVER['HTTP_REFERER'] ?? 'index.php', false); }
 ?>
 <?php

--- a/customers/edit_customer.php
+++ b/customers/edit_customer.php
@@ -9,7 +9,7 @@
 $page_title = 'Edit Customer';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(2);
+page_require_level(ROLE_SUPERVISOR);
 
 $customer = find_by_id('customers', (int)$_GET['id']);
 

--- a/includes/sql.php
+++ b/includes/sql.php
@@ -9,7 +9,9 @@
 // can call prune_failed_logins() and page_require_level() via audit hooks,
 // which reference these constants before the rest of this file has loaded.
 if (!defined('ROLE_ADMIN')) {
-	define('ROLE_ADMIN', 1); // group_level 1 = Admin (bypasses org-membership checks)
+	define('ROLE_ADMIN',      1); // group_level 1 = Admin (bypasses org-membership checks)
+	define('ROLE_SUPERVISOR', 2); // group_level 2 = Supervisor
+	define('ROLE_USER',       3); // group_level 3 = User (any logged-in account)
 }
 if (!defined('LOGIN_MAX_ATTEMPTS')) {
 	define('LOGIN_MAX_ATTEMPTS', 5);

--- a/orgs/add_member.php
+++ b/orgs/add_member.php
@@ -1,6 +1,6 @@
 <?php
 require_once '../includes/load.php';
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !verify_csrf()) {
 	$session->msg('d', 'Invalid request.');

--- a/orgs/delete_org.php
+++ b/orgs/delete_org.php
@@ -1,6 +1,6 @@
 <?php
 require_once '../includes/load.php';
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !verify_csrf()) {
 	$session->msg('d', 'Invalid request.');

--- a/orgs/edit_org.php
+++ b/orgs/edit_org.php
@@ -2,7 +2,7 @@
 $page_title = 'Edit Organization';
 require_once '../includes/load.php';
 if (!$session->isUserLoggedIn(true)) { redirect('../users/index.php', false); }
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 
 $org_id = (int)($_GET['id'] ?? 0);
 $org    = $org_id > 0 ? find_org_by_id($org_id) : null;

--- a/orgs/orgs.php
+++ b/orgs/orgs.php
@@ -2,7 +2,7 @@
 $page_title = 'Organizations';
 require_once '../includes/load.php';
 if (!$session->isUserLoggedIn(true)) { redirect('../users/index.php', false); }
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 
 $orgs = find_all_orgs();
 ?>

--- a/orgs/remove_member.php
+++ b/orgs/remove_member.php
@@ -1,6 +1,6 @@
 <?php
 require_once '../includes/load.php';
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !verify_csrf()) {
 	$session->msg('d', 'Invalid request.');

--- a/orgs/restore_org.php
+++ b/orgs/restore_org.php
@@ -1,6 +1,6 @@
 <?php
 require_once '../includes/load.php';
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !verify_csrf()) {
 	$session->msg('d', 'Invalid request.');

--- a/orgs/update_member.php
+++ b/orgs/update_member.php
@@ -1,6 +1,6 @@
 <?php
 require_once '../includes/load.php';
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !verify_csrf()) {
 	$session->msg('d', 'Invalid request.');

--- a/orgs/update_org.php
+++ b/orgs/update_org.php
@@ -1,6 +1,6 @@
 <?php
 require_once '../includes/load.php';
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !verify_csrf()) {
 	$session->msg('d', 'Invalid request.');

--- a/products/add_product.php
+++ b/products/add_product.php
@@ -9,7 +9,7 @@
 $page_title = 'Add Product';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(2);
+page_require_level(ROLE_SUPERVISOR);
 
 $all_categories = find_all('categories');
 $all_photo = find_all('media');

--- a/products/add_stock.php
+++ b/products/add_stock.php
@@ -9,7 +9,7 @@
 $page_title = 'All stock';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 
 $selected_product = 0;
 if ( isset($_GET['id'] ) ) {

--- a/products/categories.php
+++ b/products/categories.php
@@ -9,7 +9,7 @@
 $page_title = 'All Categories';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 
 $all_categories = find_all('categories')
 ?>

--- a/products/delete_category.php
+++ b/products/delete_category.php
@@ -8,7 +8,7 @@
 
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 if (!verify_get_csrf()) { $session->msg('d', 'Invalid or missing security token.'); redirect($_SERVER['HTTP_REFERER'] ?? 'index.php', false); }
 ?>
 <?php

--- a/products/delete_media.php
+++ b/products/delete_media.php
@@ -8,7 +8,7 @@
 
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(2);
+page_require_level(ROLE_SUPERVISOR);
 if (!verify_get_csrf()) { $session->msg('d', 'Invalid or missing security token.'); redirect($_SERVER['HTTP_REFERER'] ?? 'index.php', false); }
 ?>
 <?php

--- a/products/delete_product.php
+++ b/products/delete_product.php
@@ -8,7 +8,7 @@
 
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(2);
+page_require_level(ROLE_SUPERVISOR);
 if (!verify_get_csrf()) { $session->msg('d', 'Invalid or missing security token.'); redirect($_SERVER['HTTP_REFERER'] ?? 'index.php', false); }
 ?>
 <?php

--- a/products/delete_stock.php
+++ b/products/delete_stock.php
@@ -8,7 +8,7 @@
 
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(2);
+page_require_level(ROLE_SUPERVISOR);
 if (!verify_get_csrf()) { $session->msg('d', 'Invalid or missing security token.'); redirect($_SERVER['HTTP_REFERER'] ?? 'index.php', false); }
 ?>
 <?php

--- a/products/edit_category.php
+++ b/products/edit_category.php
@@ -9,7 +9,7 @@
 $page_title = 'Edit category';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 ?>
 <?php
 //Display all catgories.

--- a/products/edit_product.php
+++ b/products/edit_product.php
@@ -9,7 +9,7 @@
 $page_title = 'Edit Product';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(2);
+page_require_level(ROLE_SUPERVISOR);
 $id = filter_var($_GET['id'], FILTER_VALIDATE_INT);
 $product = find_by_id('products', $id);
 $all_categories = find_all('categories');

--- a/products/edit_stock.php
+++ b/products/edit_stock.php
@@ -9,7 +9,7 @@
 $page_title = 'Edit category';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 ?>
 <?php
 //Display all catgories.

--- a/products/media.php
+++ b/products/media.php
@@ -9,7 +9,7 @@
 $page_title = 'All Image';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(2);
+page_require_level(ROLE_SUPERVISOR);
 ?>
 <?php $media_files = find_all('media');?>
 <?php

--- a/products/product_search.php
+++ b/products/product_search.php
@@ -9,7 +9,7 @@
 $page_title = 'Product Search';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(3);
+page_require_level(ROLE_USER);
 
 ?>
 <?php include_once '../layouts/header.php'; ?>

--- a/products/products.php
+++ b/products/products.php
@@ -9,7 +9,7 @@
 $page_title = 'All Product';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(2);
+page_require_level(ROLE_SUPERVISOR);
 
 $all_categories = find_all('categories');
 $selected_category = 0;

--- a/products/stock.php
+++ b/products/stock.php
@@ -9,7 +9,7 @@
 $page_title = 'All stock';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 
 $all_stock = find_all('stock');
 $all_products = find_all('products');

--- a/products/view_product.php
+++ b/products/view_product.php
@@ -9,7 +9,7 @@
 $page_title = 'All Product';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(2);
+page_require_level(ROLE_SUPERVISOR);
 
 if ( isset( $_GET['id'] ) ) {
 	$product = find_by_id('products', (int)$_GET['id']);

--- a/reports/daily_sales.php
+++ b/reports/daily_sales.php
@@ -9,7 +9,7 @@
 $page_title = 'Daily Sales';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(3);
+page_require_level(ROLE_USER);
 ?>
 
 <?php

--- a/reports/monthly_sales.php
+++ b/reports/monthly_sales.php
@@ -9,7 +9,7 @@
 $page_title = 'Monthly Sales';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(3);
+page_require_level(ROLE_USER);
 ?>
 <?php
 $year = date('Y');

--- a/reports/sale_report_process.php
+++ b/reports/sale_report_process.php
@@ -10,7 +10,7 @@ $page_title = 'Sales Report';
 $results = '';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(3);
+page_require_level(ROLE_USER);
 if (!verify_csrf()) { $session->msg('d', 'Invalid or missing security token.'); redirect($_SERVER['HTTP_REFERER'] ?? 'index.php', false); }
 ?>
 <?php

--- a/reports/sales_report.php
+++ b/reports/sales_report.php
@@ -9,7 +9,7 @@
 $page_title = 'Sale Report';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(3);
+page_require_level(ROLE_USER);
 ?>
 <?php include_once '../layouts/header.php'; ?>
 <div class="row">

--- a/reports/stock_report.php
+++ b/reports/stock_report.php
@@ -17,7 +17,7 @@
 $page_title = 'Stock Report';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(3);
+page_require_level(ROLE_USER);
 $all_categories = find_all('categories');
 if (!verify_csrf()) { $session->msg('d', 'Invalid or missing security token.'); redirect($_SERVER['HTTP_REFERER'] ?? 'index.php', false); }
   if ( isset($_POST['update_category'] ) ) {

--- a/reports/stock_report_process.php
+++ b/reports/stock_report_process.php
@@ -9,7 +9,7 @@
 $page_title = 'Stock Report';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(3);
+page_require_level(ROLE_USER);
 if (!verify_csrf()) { $session->msg('d', 'Invalid or missing security token.'); redirect($_SERVER['HTTP_REFERER'] ?? 'index.php', false); }
 
 if (isset($_POST['submit'])) {

--- a/sales/add_order.php
+++ b/sales/add_order.php
@@ -9,7 +9,7 @@
 $page_title = 'Add Order';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 
 ?>
 <?php

--- a/sales/add_order_by_customer.php
+++ b/sales/add_order_by_customer.php
@@ -9,7 +9,7 @@
 $page_title = 'Add Order';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 
 $all_orders = find_all('orders');
 $order_id = last_id('orders');

--- a/sales/add_sale_by_search.php
+++ b/sales/add_sale_by_search.php
@@ -9,7 +9,7 @@
 $page_title = 'Add Sale by Search';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(3);
+page_require_level(ROLE_USER);
 $order_id = 0;
 
 if (isset($_GET['id'])) {

--- a/sales/add_sale_by_sku.php
+++ b/sales/add_sale_by_sku.php
@@ -9,7 +9,7 @@
 $page_title = 'Add Sale by SKU';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(3);
+page_require_level(ROLE_USER);
 
 $order_id = last_id('orders');
 $o_id = $order_id['id'];

--- a/sales/add_sale_to_order.php
+++ b/sales/add_sale_to_order.php
@@ -9,7 +9,7 @@
 $page_title = 'Add Sale';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(3);
+page_require_level(ROLE_USER);
 $order_id = 0;
 $selected_category = 0;
 if (!verify_csrf()) { $session->msg('d', 'Invalid or missing security token.'); redirect($_SERVER['HTTP_REFERER'] ?? 'index.php', false); }

--- a/sales/delete_order.php
+++ b/sales/delete_order.php
@@ -8,7 +8,7 @@
 
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(2);
+page_require_level(ROLE_SUPERVISOR);
 if (!verify_get_csrf()) { $session->msg('d', 'Invalid or missing security token.'); redirect($_SERVER['HTTP_REFERER'] ?? 'index.php', false); }
 ?>
 <?php

--- a/sales/delete_sale.php
+++ b/sales/delete_sale.php
@@ -8,7 +8,7 @@
 
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(2);
+page_require_level(ROLE_SUPERVISOR);
 if (!verify_get_csrf()) { $session->msg('d', 'Invalid or missing security token.'); redirect($_SERVER['HTTP_REFERER'] ?? 'index.php', false); }
 ?>
 <?php

--- a/sales/edit_order.php
+++ b/sales/edit_order.php
@@ -9,7 +9,7 @@
 $page_title = 'Edit Order';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(2);
+page_require_level(ROLE_SUPERVISOR);
 
 
 //Display all catgories.

--- a/sales/edit_sale.php
+++ b/sales/edit_sale.php
@@ -9,7 +9,7 @@
 $page_title = 'Edit sale';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(3);
+page_require_level(ROLE_USER);
 ?>
 
 

--- a/sales/order_picklist.php
+++ b/sales/order_picklist.php
@@ -10,7 +10,7 @@ $page_title = 'Order Picklist';
 
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(3);
+page_require_level(ROLE_USER);
 $order_id  = 0;
 
 if (isset($_GET['id'])) {

--- a/sales/orders.php
+++ b/sales/orders.php
@@ -9,7 +9,7 @@
 $page_title = 'All Orders';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 
 $all_orders = find_all('orders');
 $orders = array_reverse($all_orders);

--- a/sales/sales.php
+++ b/sales/sales.php
@@ -9,7 +9,7 @@
 $page_title = 'All Sales';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(3);
+page_require_level(ROLE_USER);
 ?>
 
 <?php $sales = find_all_sales(); ?>

--- a/sales/sales_by_order.php
+++ b/sales/sales_by_order.php
@@ -9,7 +9,7 @@
 $page_title = 'Sales by Order';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(3);
+page_require_level(ROLE_USER);
 
 $order_id  = 0;
 

--- a/sales/sales_invoice.php
+++ b/sales/sales_invoice.php
@@ -9,7 +9,7 @@
 $page_title = 'Sales Invoice';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(3);
+page_require_level(ROLE_USER);
 $order_id  = 0;
 $order_total = 0;
 

--- a/users/add_group.php
+++ b/users/add_group.php
@@ -9,7 +9,7 @@
 $page_title = 'Add Group';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 ?>
 <?php
 if (!verify_csrf()) { $session->msg('d', 'Invalid or missing security token.'); redirect($_SERVER['HTTP_REFERER'] ?? 'index.php', false); }

--- a/users/add_user.php
+++ b/users/add_user.php
@@ -9,7 +9,7 @@
 $page_title = 'Add User';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 
 
 $groups = find_all('user_groups');

--- a/users/admin.php
+++ b/users/admin.php
@@ -9,7 +9,7 @@
 $page_title = 'Admin Home Page';
 require_once '../includes/load.php';
 
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 
 $c_categories     = count_by_id('categories');
 $c_products       = count_by_id('products');

--- a/users/change_password.php
+++ b/users/change_password.php
@@ -9,7 +9,7 @@
 $page_title = 'Change Password';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(3);
+page_require_level(ROLE_USER);
 ?>
 <?php $user = current_user(); ?>
 <?php

--- a/users/delete_group.php
+++ b/users/delete_group.php
@@ -8,7 +8,7 @@
 
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 if (!verify_get_csrf()) { $session->msg('d', 'Invalid or missing security token.'); redirect($_SERVER['HTTP_REFERER'] ?? 'index.php', false); }
 ?>
 <?php

--- a/users/delete_log.php
+++ b/users/delete_log.php
@@ -8,7 +8,7 @@
 
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(2);
+page_require_level(ROLE_SUPERVISOR);
 if (!verify_get_csrf()) { $session->msg('d', 'Invalid or missing security token.'); redirect($_SERVER['HTTP_REFERER'] ?? 'index.php', false); }
 
 $id = filter_var($_GET['id'], FILTER_VALIDATE_INT);

--- a/users/delete_log_by_ip.php
+++ b/users/delete_log_by_ip.php
@@ -8,7 +8,7 @@
 
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(2);
+page_require_level(ROLE_SUPERVISOR);
 if (!verify_get_csrf()) { $session->msg('d', 'Invalid or missing security token.'); redirect($_SERVER['HTTP_REFERER'] ?? 'index.php', false); }
 
 if ( isset($_GET['ip']) ) {

--- a/users/delete_user.php
+++ b/users/delete_user.php
@@ -8,7 +8,7 @@
 
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 if (!verify_get_csrf()) { $session->msg('d', 'Invalid or missing security token.'); redirect($_SERVER['HTTP_REFERER'] ?? 'index.php', false); }
 ?>
 <?php

--- a/users/edit_account.php
+++ b/users/edit_account.php
@@ -8,7 +8,7 @@
 
 $page_title = 'Edit Account';
 require_once '../includes/load.php';
-page_require_level(3);
+page_require_level(ROLE_USER);
 ?>
 <?php
 //update user image

--- a/users/edit_category.php
+++ b/users/edit_category.php
@@ -9,7 +9,7 @@
 $page_title = 'Edit Category';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 ?>
 <?php
 //Display all catgories.

--- a/users/edit_group.php
+++ b/users/edit_group.php
@@ -9,7 +9,7 @@
 $page_title = 'Edit Group';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 ?>
 
 <!--     *************************     -->

--- a/users/edit_user.php
+++ b/users/edit_user.php
@@ -9,7 +9,7 @@
 $page_title = 'Edit User';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 ?>
 
 <!--     *************************     -->

--- a/users/group.php
+++ b/users/group.php
@@ -9,7 +9,7 @@
 $page_title = 'All Group';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 
 $all_groups = find_all('user_groups');
 

--- a/users/home.php
+++ b/users/home.php
@@ -9,7 +9,7 @@
 $page_title = 'Home Page';
 require_once '../includes/load.php';
 if (!$session->isUserLoggedIn(true)) { redirect('index.php', false);}
-page_require_level(3);
+page_require_level(ROLE_USER);
 
 $products_sold   = find_highest_selling_product('10');
 $recent_products = find_recent_product_added('5');

--- a/users/log.php
+++ b/users/log.php
@@ -9,7 +9,7 @@
 $page_title = 'All logs';
 require_once '.././includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(2);
+page_require_level(ROLE_SUPERVISOR);
 
 /**
  * CoreConduit Copyright (C) 2016 Cory J. Potter - All Rights Reserved

--- a/users/profile.php
+++ b/users/profile.php
@@ -9,7 +9,7 @@
 $page_title = 'My Profile';
 require_once '../includes/load.php';
 // Checkin What level user has permission to view this page
-page_require_level(3);
+page_require_level(ROLE_USER);
 ?>
   <?php
 $user_id = (int)$_GET['id'];

--- a/users/purge.php
+++ b/users/purge.php
@@ -7,7 +7,7 @@
  */
 
 require_once '../includes/load.php';
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     redirect('trash.php', false);

--- a/users/restore.php
+++ b/users/restore.php
@@ -6,7 +6,7 @@
  */
 
 require_once '../includes/load.php';
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     redirect('trash.php', false);

--- a/users/settings.php
+++ b/users/settings.php
@@ -11,7 +11,7 @@
 
 $page_title = 'Settings';
 require_once '../includes/load.php';
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 
 $current_currency = Settings::get('currency_code', 'USD');
 $supported = supported_currency_codes();

--- a/users/switch_org.php
+++ b/users/switch_org.php
@@ -6,7 +6,7 @@
  * before updating session and last_active_org_id.
  */
 require_once '../includes/load.php';
-page_require_level(3);
+page_require_level(ROLE_USER);
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !verify_csrf()) {
 	$session->msg('d', 'Invalid security token. Please try again.');

--- a/users/trash.php
+++ b/users/trash.php
@@ -8,7 +8,7 @@
  */
 
 require_once '../includes/load.php';
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 
 // SOFT_DELETE_TABLES is defined in includes/sql.php (Task 7).
 $table = isset($_GET['table']) ? (string)$_GET['table'] : 'users';

--- a/users/users.php
+++ b/users/users.php
@@ -15,7 +15,7 @@ require_once '../includes/load.php';
 
 <?php
 // Checkin What level user has permission to view this page
-page_require_level(1);
+page_require_level(ROLE_ADMIN);
 //pull out all user form database
 
 $all_users = find_all_user();


### PR DESCRIPTION
- Defines `ROLE_SUPERVISOR = 2` and `ROLE_USER = 3` alongside the existing `ROLE_ADMIN = 1` in `sql.php`
- Replaces all 65+ numeric `page_require_level(1/2/3)` call sites with named constants across the entire codebase
- No logic changes — pure readability/safety refactor
During PR2 smoke testing, `switch_org.php` caused an HTTP 500 because it used the undefined constant `ROLE_USER`. PHP 7 silently coerced undefined constants to their string name; PHP 8 makes this a fatal `Error`. Named constants defined before `load.php` eliminate this class of bug entirely.
This is **not** full shim removal. The `page_require_level()` function itself is retained — replacing it with `require_org_role()` at all call sites requires `require_org_role()` to also handle account-disabled and group-disabled checks, which is deferred to a future PR.
- [x] `bash tests/run.sh` — 8/8 suites pass (96+ cases)
- [x] Pre-commit PHP lint clean on all 70 changed files
- [x] No numeric literals remain: `grep -rn 'page_require_level([0-9]' --include="*.php"` returns empty